### PR TITLE
fix: Incompatibility of HCL update and subsume

### DIFF
--- a/acceptance-tests/mssql_db_subsume_test.go
+++ b/acceptance-tests/mssql_db_subsume_test.go
@@ -56,8 +56,7 @@ var _ = Describe("MSSQL DB Subsume", Label("mssql-db"), func() {
 
 		serviceBroker := brokers.Create(
 			brokers.WithPrefix("csb-mssql-db"),
-			// Disable brokerpak_updates due to bug - https://www.pivotaltracker.com/story/show/180586187
-			brokers.WithEnv(apps.EnvVar{Name: "MSSQL_DB_SERVER_CREDS", Value: creds}, apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: false}),
+			brokers.WithEnv(apps.EnvVar{Name: "MSSQL_DB_SERVER_CREDS", Value: creds}),
 		)
 		defer serviceBroker.Delete()
 

--- a/acceptance-tests/mssql_fog_db_subsume_test.go
+++ b/acceptance-tests/mssql_fog_db_subsume_test.go
@@ -70,8 +70,7 @@ var _ = Describe("MSSQL Failover Group DB Subsume", Label("mssql-db-failover-gro
 		serverPairTag := random.Name(random.WithMaxLength(10))
 		serviceBroker := brokers.Create(
 			brokers.WithPrefix("csb-mssql-fog-db"),
-			// Disable brokerpak_updates due to bug - https://www.pivotaltracker.com/story/show/180586187
-			brokers.WithEnv(apps.EnvVar{Name: "MSSQL_DB_FOG_SERVER_PAIR_CREDS", Value: serverPairsConfig(serverPairTag)}, apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: false}),
+			brokers.WithEnv(apps.EnvVar{Name: "MSSQL_DB_FOG_SERVER_PAIR_CREDS", Value: serverPairsConfig(serverPairTag)}),
 		)
 		defer serviceBroker.Delete()
 

--- a/azure-mssql-db-failover.yml
+++ b/azure-mssql-db-failover.yml
@@ -136,6 +136,7 @@ provision:
     default: csb-fog-db-${request.instance_id}
     constraints:
       maxLength: 64
+    tf_attribute: azurerm_mssql_database.primary_db.name
   - field_name: server_pair
     type: string
     details: Name of server pair from server_credential_pairs to create database upon

--- a/azure-mssql-db.yml
+++ b/azure-mssql-db.yml
@@ -102,6 +102,7 @@ provision:
     default: csb-db-${request.instance_id}
     constraints:
       maxLength: 64
+    tf_attribute: azurerm_mssql_database.azure_sql_db.name
   - field_name: server
     type: string
     details: Name of server from server_credentials to create database upon

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -4,4 +4,6 @@
 
 
 ### Fix:
+- Update operation on subsumed instances succeeds when brokerpak update is enabled (via `BROKERPAK_UPDATES_ENABLED`). 
+Previously update was failing due to variables not being stored during subsume operaiton. 
 


### PR DESCRIPTION
tf_attribute set to extract the fields from the tf state during update

[#180586187](https://www.pivotaltracker.com/story/show/180586187)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

