### PR TITLE
chore: improve Go version check

### DIFF
--- a/tools/psqlcmd/Makefile
+++ b/tools/psqlcmd/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-GO-VERSION = 1.18
+GO-VERSION = 1.18.1
 GO-VER = go$(GO-VERSION)
 
 SRC = $(shell find . -name "*.go" | grep -v "_test\." )
@@ -27,9 +27,12 @@ EXE_NAME=psqlcmd
 
 .PHONY: deps-go-binary
 deps-go-binary:
-	echo "Expect: $(GO-VER)" && \
-		echo "Actual: $$($(GO) version)" && \
-	 	$(GO) version | grep $(GO-VER) > /dev/null
+ifeq ($(SKIP_GO_VERSION_CHECK),)
+	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+		exit 1; \
+	fi
+endif
 
 HAS_GO_IMPORTS := $(shell command -v goimports;)
 
@@ -39,7 +42,7 @@ ifndef HAS_GO_IMPORTS
 endif
 
 .PHONY: build
-build: ./build/$(EXE_NAME)_$(VERSION)_linux_amd64.zip ./build/$(EXE_NAME)_$(VERSION)_darwin_amd64.zip
+build: deps-go-binary ./build/$(EXE_NAME)_$(VERSION)_linux_amd64.zip ./build/$(EXE_NAME)_$(VERSION)_darwin_amd64.zip
 
 # ./build:
 # 	mkdir -p ./build

--- a/tools/sqlfailover/Makefile
+++ b/tools/sqlfailover/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-GO-VERSION = 1.18
+GO-VERSION = 1.18.1
 GO-VER = go$(GO-VERSION)
 
 SRC = $(shell find . -name "*.go" | grep -v "_test\." )
@@ -27,9 +27,12 @@ EXE_NAME=sqlfailover
 
 .PHONY: deps-go-binary
 deps-go-binary:
-	echo "Expect: $(GO-VER)" && \
-		echo "Actual: $$($(GO) version)" && \
-	 	$(GO) version | grep $(GO-VER) > /dev/null
+ifeq ($(SKIP_GO_VERSION_CHECK),)
+	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+		exit 1; \
+	fi
+endif
 
 HAS_GO_IMPORTS := $(shell command -v goimports;)
 
@@ -39,7 +42,7 @@ ifndef HAS_GO_IMPORTS
 endif
 
 .PHONY: build
-build: ./build/$(EXE_NAME)_$(VERSION)_linux_amd64.zip ./build/$(EXE_NAME)_$(VERSION)_darwin_amd64.zip
+build: deps-go-binary ./build/$(EXE_NAME)_$(VERSION)_linux_amd64.zip ./build/$(EXE_NAME)_$(VERSION)_darwin_amd64.zip
 
 ./build/$(EXE_NAME)_$(VERSION)_linux_amd64.zip: build/linux/$(EXE_NAME)
 	zip -j -r $@ $<


### PR DESCRIPTION
- new check only prints when there is an error
- new check does not allow substring matches

[#181960182](https://www.pivotaltracker.com/story/show/181960182)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

