### PR TITLE
feat: csbsqlserver provider should drop legacy logins

### DIFF
--- a/providers/terraform-provider-csbsqlserver/connector/connector.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector.go
@@ -49,9 +49,11 @@ func (c *Connector) CreateBinding(ctx context.Context, username, password string
 // DeleteBinding drops the binding user. It is idempotent.
 func (c *Connector) DeleteBinding(ctx context.Context, username string) error {
 	return c.withConnection(func(db *sql.DB) error {
-		statement := fmt.Sprintf(`DROP USER IF EXISTS [%s]`, username)
-		if _, err := db.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("error deleting user %q: %w", username, err)
+		if err := dropUser(ctx, db, username); err != nil {
+			return err
+		}
+		if err := dropLogin(ctx, db, username); err != nil {
+			return err
 		}
 
 		return nil
@@ -100,6 +102,46 @@ func checkUser(ctx context.Context, db *sql.DB, username string) (bool, error) {
 	}
 	defer rows.Close()
 	return rows.Next(), nil
+}
+
+func checkLogin(ctx context.Context, db *sql.DB, username string) (bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT NAME FROM sys.sql_logins WHERE NAME = @p1`, username)
+	if err != nil {
+		return false, fmt.Errorf("error querying existence of login %q: %w", username, err)
+	}
+	defer rows.Close()
+	return rows.Next(), nil
+}
+
+func dropUser(ctx context.Context, db *sql.DB, username string) error {
+	statement := fmt.Sprintf(`DROP USER IF EXISTS [%s]`, username)
+	if _, err := db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("error deleting user %q: %w", username, err)
+	}
+
+	return nil
+}
+
+// dropLogin drops a legacy login. In the past the brokerpak created a login and
+// then created a user from the login, but this was problematic in a failover because
+// the login did not exist on the replica. See: https://www.pivotaltracker.com/story/show/179168006
+// In order to clean up any legacy login, we check to see if one exists and
+// drop it if it does.
+func dropLogin(ctx context.Context, db *sql.DB, username string) error {
+	exists, err := checkLogin(ctx, db, username)
+	switch {
+	case err != nil:
+		return err
+	case !exists:
+		return nil
+	}
+
+	statement := fmt.Sprintf(`DROP LOGIN [%s]`, username)
+	if _, err := db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("error deleting login %q: %w", username, err)
+	}
+
+	return nil
 }
 
 func createUser(ctx context.Context, db *sql.DB, username, password string) error {


### PR DESCRIPTION
- this is to match a previous behaviour
- also improved the waiting for test server to start

[#182571088](https://www.pivotaltracker.com/story/show/182571088)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ (not needed)
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

