### PR TITLE
chore: put upgrade tests on memory diet

### DIFF
--- a/acceptance-tests/helpers/apps/push.go
+++ b/acceptance-tests/helpers/apps/push.go
@@ -16,7 +16,10 @@ const pushWaitTime = 20 * time.Minute
 type Option func(*App)
 
 func Push(opts ...Option) *App {
-	defaults := []Option{WithName(random.Name(random.WithPrefix("app")))}
+	defaults := []Option{
+		WithName(random.Name(random.WithPrefix("app"))),
+		WithMemory("100MB"),
+	}
 	app := App{}
 	app.Push(append(defaults, opts...)...)
 	return &app
@@ -104,6 +107,12 @@ func WithVariable(key, value string) Option {
 func WithStartedState() Option {
 	return func(a *App) {
 		a.start = true
+	}
+}
+
+func WithMemory(memory string) Option {
+	return func(a *App) {
+		a.memory = memory
 	}
 }
 

--- a/acceptance-tests/helpers/brokers/create.go
+++ b/acceptance-tests/helpers/brokers/create.go
@@ -18,6 +18,7 @@ func Create(opts ...Option) *Broker {
 		apps.WithName(broker.Name),
 		apps.WithDir(broker.dir),
 		apps.WithManifest(fmt.Sprintf("%s/cf-manifest.yml", broker.dir)),
+		apps.WithMemory("250MB"),
 		apps.WithVariable("app", broker.Name),
 	)
 	brokerApp.SetEnv(broker.env()...)


### PR DESCRIPTION
Each broker and test app was allocated 1GB, which is far more than they
actually need. Reduced to about double what they need to give them some head
room.

[#182571088](https://www.pivotaltracker.com/story/show/182571088)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

