### PR TITLE
test: upgrade all services to enable cleanup

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_test.go
@@ -89,7 +89,10 @@ var _ = Describe("UpgradeMssqlDBFailoverTest", Label("mssql-db-failover"), func(
 			By("pushing the development version of the broker")
 			serviceBroker.UpgradeBroker(developmentBuildDir)
 
-			By("upgrading service instance")
+			By("upgrading previous services")
+			resourceGroupInstance.Upgrade()
+			serverInstancePrimary.Upgrade()
+			serverInstanceSecondary.Upgrade()
 			initialFogInstance.Upgrade()
 
 			By("getting the previously set value using the second app")


### PR DESCRIPTION
now that we are upgrading the tf version between brokers
we must upgrade all the previous service instances to allow
test cleanup.

[#182635325](https://www.pivotaltracker.com/story/show/182635325)

### Checklist:

~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

