### PR TITLE
test: only assert data available after upgrade

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -56,12 +56,6 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			By("checking previously written data still accessible")
 			Expect(appTwo.GET(key1)).To(Equal(value1))
 
-			By("updating the instance plan")
-			serviceInstance.Update("-p", "medium")
-
-			By("checking previously written data still accessible")
-			Expect(appTwo.GET(key1)).To(Equal(value1))
-
 			By("deleting bindings created before the upgrade")
 			bindingOne.Unbind()
 			bindingTwo.Unbind()
@@ -75,7 +69,7 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			appOne.PUT(value2, key2)
 			Expect(appTwo.GET(key2)).To(Equal(value2))
 
-			By("getting the value using the second app")
+			By("checking previously written data still accessible")
 			Expect(appTwo.GET(key1)).To(Equal(value1))
 
 			By("updating the instance plan")


### PR DESCRIPTION
Reverting back to previous test structure which did not
assert that data persists after plan update. Only checking
that upgrade does not result in data loss.

[#182635325](https://www.pivotaltracker.com/story/show/182635325)

### Checklist:

~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

