### PR TITLE
fix: use one() function to pass TF syntax check

### DIFF
--- a/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
@@ -30,7 +30,7 @@ resource "azurerm_mssql_database" "secondary_db" {
   sku_name                    = local.sku_name
   tags                        = var.labels
   create_mode                 = "Secondary"
-  creation_source_database_id = azurerm_mssql_database.primary_db[0].id
+  creation_source_database_id = azurerm_mssql_database.primary_db[count.index].id
   count                       = var.existing ? 0 : 1
 }
 
@@ -38,7 +38,7 @@ resource "azurerm_sql_failover_group" "failover_group" {
   name                = var.instance_name
   resource_group_name = var.server_credential_pairs[var.server_pair].primary.resource_group
   server_name         = data.azurerm_sql_server.primary_sql_db_server.name
-  databases           = [azurerm_mssql_database.primary_db[0].id]
+  databases           = [azurerm_mssql_database.primary_db[count.index].id]
   partner_servers {
     id = data.azurerm_sql_server.secondary_sql_db_server.id
   }

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
@@ -1,9 +1,9 @@
-output "sqldbName" { value = var.existing ? var.db_name : azurerm_mssql_database.primary_db[0].name }
-output "sqlServerName" { value = var.existing ? var.instance_name : azurerm_sql_failover_group.failover_group[0].name }
-output "sqlServerFullyQualifiedDomainName" { value = format("%s.database.windows.net", var.existing ? var.instance_name : azurerm_sql_failover_group.failover_group[0].name) }
-output "hostname" { value = format("%s.database.windows.net", var.existing ? var.instance_name : azurerm_sql_failover_group.failover_group[0].name) }
+output "sqldbName" { value = var.existing ? var.db_name : one(azurerm_mssql_database.primary_db[*].name) }
+output "sqlServerName" { value = var.existing ? var.instance_name : one(azurerm_sql_failover_group.failover_group[*].name) }
+output "sqlServerFullyQualifiedDomainName" { value = format("%s.database.windows.net", var.existing ? var.instance_name : one(azurerm_sql_failover_group.failover_group[*].name)) }
+output "hostname" { value = format("%s.database.windows.net", var.existing ? var.instance_name : one(azurerm_sql_failover_group.failover_group[*].name)) }
 output "port" { value = 1433 }
-output "name" { value = var.existing ? var.db_name : azurerm_mssql_database.primary_db[0].name }
+output "name" { value = var.existing ? var.db_name : one(azurerm_mssql_database.primary_db[*].name) }
 output "username" { value = var.server_credential_pairs[var.server_pair].admin_username }
 output "password" { value = var.server_credential_pairs[var.server_pair].admin_password }
 output "server_pair" { value = var.server_pair }
@@ -13,10 +13,10 @@ output "status" {
     data.azurerm_sql_server.secondary_sql_db_server.name, data.azurerm_sql_server.secondary_sql_db_server.id,
     var.azure_tenant_id,
     data.azurerm_sql_server.primary_sql_db_server.id) : format("created failover group %s (id: %s), primary db %s (id: %s) on server %s (id: %s), secondary db %s (id: %s/databases/%s) on server %s (id: %s) URL: https://portal.azure.com/#@%s/resource%s/failoverGroup",
-    azurerm_sql_failover_group.failover_group[0].name, azurerm_sql_failover_group.failover_group[0].id,
-    azurerm_sql_failover_group.failover_group[0].name, azurerm_mssql_database.primary_db[0].id,
+    one(azurerm_sql_failover_group.failover_group[*].name), one(azurerm_sql_failover_group.failover_group[*].id),
+    one(azurerm_sql_failover_group.failover_group[*].name), one(azurerm_mssql_database.primary_db[*].id),
     data.azurerm_sql_server.primary_sql_db_server.name, data.azurerm_sql_server.primary_sql_db_server.id,
-    azurerm_mssql_database.primary_db[0].name, data.azurerm_sql_server.secondary_sql_db_server.id, azurerm_mssql_database.primary_db[0].name,
+    one(azurerm_mssql_database.primary_db[*].name), data.azurerm_sql_server.secondary_sql_db_server.id, one(azurerm_mssql_database.primary_db[*].name),
     data.azurerm_sql_server.secondary_sql_db_server.name, data.azurerm_sql_server.secondary_sql_db_server.id,
     var.azure_tenant_id,
   data.azurerm_sql_server.primary_sql_db_server.id)


### PR DESCRIPTION
on versions of Terraform >0.12 the outputs were failing
as they were being validated while the primary_db resource was
still null. This change ensures that either a null value or correct
value is returned, whereas previously we were indexing an empty object
causing a failure.

More info on the [one function](https://www.terraform.io/language/functions/one)

[#182635325](https://www.pivotaltracker.com/story/show/182635325)

### Checklist:

~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

