### PR TITLE
fix: ensure resource exists before accessing

### DIFF
--- a/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
@@ -30,7 +30,7 @@ resource "azurerm_mssql_database" "secondary_db" {
   sku_name                    = local.sku_name
   tags                        = var.labels
   create_mode                 = "Secondary"
-  creation_source_database_id = azurerm_mssql_database.primary_db[0].id
+  creation_source_database_id = azurerm_mssql_database.primary_db[count.index].id
   count                       = var.existing ? 0 : 1
 }
 
@@ -38,7 +38,7 @@ resource "azurerm_sql_failover_group" "failover_group" {
   name                = var.instance_name
   resource_group_name = var.server_credential_pairs[var.server_pair].primary.resource_group
   server_name         = data.azurerm_sql_server.primary_sql_db_server.name
-  databases           = [azurerm_mssql_database.primary_db[0].id]
+  databases           = [azurerm_mssql_database.primary_db[count.index].id]
   partner_servers {
     id = data.azurerm_sql_server.secondary_sql_db_server.id
   }


### PR DESCRIPTION
during the terraform import step in versions >= 0.13 all
variable values are interpreted. We previously were accessing a
resource which at this point in time had not been instantiated resulting
in a failure. This fix ensures that the resource value is only accessed
once it exists.

[#182635325](https://www.pivotaltracker.com/story/show/182635325)

### Checklist:

~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

