### PR TITLE
fix: build brokerpak on Mac

### DIFF
--- a/providers/terraform-provider-csbmssqldbrunfailover/Makefile
+++ b/providers/terraform-provider-csbmssqldbrunfailover/Makefile
@@ -1,6 +1,5 @@
 .DEFAULT_GOAL = help
 
-OS := $(shell uname -s | tr A-Z a-z)
 GO-VERSION = 1.18.3
 GO-VER = go$(GO-VERSION)
 GO_OK :=  $(or $(USE_GO_CONTAINERS), $(shell which go 1>/dev/null 2>/dev/null; echo $$?))
@@ -20,8 +19,10 @@ help: ## list Makefile targets
 build: deps-go-binary cloudfoundry.org ## build the provider
 
 cloudfoundry.org: *.go */*.go
-	mkdir -p cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/${OS}_amd64
-	GOOS=$(OS) $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/${OS}_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
+	mkdir -p cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/linux_amd64
+	mkdir -p cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/darwin_amd64
+	GOOS=linux $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/linux_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
+	GOOS=darwin $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/darwin_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
 
 .PHONY: clean
 clean: ## clean up build artifacts

--- a/providers/terraform-provider-csbsqlserver/Makefile
+++ b/providers/terraform-provider-csbsqlserver/Makefile
@@ -1,6 +1,5 @@
 .DEFAULT_GOAL = help
 
-OS := $(shell uname -s | tr A-Z a-z)
 GO-VERSION = 1.18.3
 GO-VER = go$(GO-VERSION)
 GO_OK :=  $(or $(USE_GO_CONTAINERS), $(shell which go 1>/dev/null 2>/dev/null; echo $$?))
@@ -20,8 +19,10 @@ help: ## list Makefile targets
 build: deps-go-binary cloudfoundry.org ## build the provider
 
 cloudfoundry.org: *.go */*.go
-	mkdir -p cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/${OS}_amd64
-	GOOS=$(OS) $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/${OS}_amd64/terraform-provider-csbsqlserver_v1.0.0
+	mkdir -p cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/linux_amd64
+	mkdir -p cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/darwin_amd64
+	GOOS=linux $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/linux_amd64/terraform-provider-csbsqlserver_v1.0.0
+	GOOS=darwin $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/darwin_amd64/terraform-provider-csbsqlserver_v1.0.0
 
 .PHONY: clean
 clean: ## clean up build artifacts


### PR DESCRIPTION
A well-intentioned optimisation has broken the ability to build a
brokerpak on a Mac. This is because on a Mac it's necessary to
cross-compile linux binaries, and Mac binaries are often useful too for
being able to run locally. We should probably avoid building Mac binaries
on a Linux desktop, and that could be a future enhancement.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ break and fix will be in same release
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

