### PR TITLE
fix: restore azurerm@v2.33 and v2.20 Terraform providers

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -37,6 +37,12 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
   default: true
 - name: terraform-provider-azurerm
+  version: 2.20.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.20.0.zip
+- name: terraform-provider-azurerm
+  version: 2.33.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.33.0.zip
+- name: terraform-provider-azurerm
   version: 2.99.0
   source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.99.0.zip
 - name: terraform-provider-random


### PR DESCRIPTION
- In previous versions, a `~>` provider version constraint was used
which restricts the version to patch fixes only.
- In this version we will update all the HCL with this constraint, but
just before the upgrade process we will perform a "terraform show" which
will evaluate the `~>` constraint and will fail if the matching version
of the provider is not present.
- Versions 2.33.0 and 2.20.0 have been shipped previously, and this
change adds both of those versions back until we are sure that all
customers have upgraded and the `~>` constraint is no longer in use.

[#182413672](https://www.pivotaltracker.com/story/show/182413672)

### Checklist:

* ~~[x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ part of upgrade feature
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

