### PR TITLE
fix: add additional lifecycle.prevent_destroy to MongoDB

### DIFF
--- a/terraform/azure-mongodb/azure-mongodb.tf
+++ b/terraform/azure-mongodb/azure-mongodb.tf
@@ -124,6 +124,10 @@ resource "azurerm_cosmosdb_account" "mongo-account" {
   capabilities {
     name = "EnableMongo"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_cosmosdb_mongo_database" "mongo-db" {
@@ -155,6 +159,10 @@ resource "azurerm_cosmosdb_mongo_collection" "mongo-collection" {
     keys   = ["_id"]
     unique = true
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_private_endpoint" "private_endpoint" {
@@ -185,8 +193,12 @@ output "uri" {
   value     = replace(azurerm_cosmosdb_account.mongo-account.connection_strings[0], "/?", "/${azurerm_cosmosdb_mongo_database.mongo-db.name}?")
   sensitive = true
 }
-output "status" { value = format("created db %s (id: %s) URL:  https://portal.azure.com/#@%s/resource%s",
-  azurerm_cosmosdb_mongo_database.mongo-db.name,
-  azurerm_cosmosdb_mongo_database.mongo-db.id,
-  var.azure_tenant_id,
-azurerm_cosmosdb_mongo_database.mongo-db.id) }
+output "status" {
+  value = format(
+    "created db %s (id: %s) URL:  https://portal.azure.com/#@%s/resource%s",
+    azurerm_cosmosdb_mongo_database.mongo-db.name,
+    azurerm_cosmosdb_mongo_database.mongo-db.id,
+    var.azure_tenant_id,
+    azurerm_cosmosdb_mongo_database.mongo-db.id,
+  )
+}


### PR DESCRIPTION
In #236 we added lifecycle.prevent_destroy to many object as a backstop
in case an updates attempted to destroy data. We have discovered that
the MongoDB account must also be preserved, as when it gets re-created
the originally written data cannot be accessed.

[#182413672](https://www.pivotaltracker.com/story/show/182413672)

### Checklist:

* ~~[x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ extension of a feature in this release
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

