### PR TITLE
chore: increase disk usage for Azure brokerpak

### DIFF
--- a/acceptance-tests/helpers/apps/app.go
+++ b/acceptance-tests/helpers/apps/app.go
@@ -7,6 +7,7 @@ type App struct {
 	start     bool
 	buildpack string
 	memory    string
+	disk      string
 	manifest  string
 	variables map[string]string
 	dir       dir

--- a/acceptance-tests/helpers/apps/push.go
+++ b/acceptance-tests/helpers/apps/push.go
@@ -19,6 +19,7 @@ func Push(opts ...Option) *App {
 	defaults := []Option{
 		WithName(random.Name(random.WithPrefix("app"))),
 		WithMemory("100MB"),
+		WithDisk("250MB"),
 	}
 	app := App{}
 	app.Push(append(defaults, opts...)...)
@@ -37,6 +38,9 @@ func (a *App) Push(opts ...Option) {
 	}
 	if a.memory != "" {
 		cmd = append(cmd, "-m", a.memory)
+	}
+	if a.disk != "" {
+		cmd = append(cmd, "-k", a.disk)
 	}
 	if a.manifest != "" {
 		cmd = append(cmd, "-f", a.manifest)
@@ -113,6 +117,12 @@ func WithStartedState() Option {
 func WithMemory(memory string) Option {
 	return func(a *App) {
 		a.memory = memory
+	}
+}
+
+func WithDisk(disk string) Option {
+	return func(a *App) {
+		a.disk = disk
 	}
 }
 

--- a/acceptance-tests/helpers/brokers/create.go
+++ b/acceptance-tests/helpers/brokers/create.go
@@ -19,6 +19,7 @@ func Create(opts ...Option) *Broker {
 		apps.WithDir(broker.dir),
 		apps.WithManifest(fmt.Sprintf("%s/cf-manifest.yml", broker.dir)),
 		apps.WithMemory("500MB"),
+		apps.WithDisk("2G"),
 		apps.WithVariable("app", broker.Name),
 	)
 	brokerApp.SetEnv(broker.env()...)

--- a/cf-manifest.yml
+++ b/cf-manifest.yml
@@ -19,6 +19,7 @@ applications:
 - name: ((app))
   command: ./cloud-service-broker serve
   memory: 1G
+  disk_quota: 2G
   buildpacks: 
   - binary_buildpack
   random-route: true


### PR DESCRIPTION
The brokerpak zip now contains many versions of Terraform and some
providers. Because of this the app is using more than 1GB of disk space.
This change increases the disk space allocated to the app.

[#182413672](https://www.pivotaltracker.com/story/show/182413672)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

