### PR TITLE
test: mssql upgrade from ancient brokerpak

### DIFF
--- a/acceptance-tests/apps/mssqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/app.go
@@ -65,3 +65,9 @@ func schemaName(r *http.Request) (string, error) {
 		return schema, nil
 	}
 }
+
+func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+	msg := fmt.Sprintf(format, a...)
+	log.Println(msg)
+	http.Error(w, msg, code)
+}

--- a/acceptance-tests/apps/mssqlapp/internal/app/drop_schema.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/drop_schema.go
@@ -14,22 +14,17 @@ func handleDropSchema(config string) func(w http.ResponseWriter, r *http.Request
 
 		schema, err := schemaName(r)
 		if err != nil {
-			log.Printf("Schema name error: %s\n", err)
-			http.Error(w, "Schema name error.", http.StatusInternalServerError)
+			fail(w, http.StatusInternalServerError, "schema name error: %s", err)
 			return
 		}
 
-		_, err = db.Exec(fmt.Sprintf(`DROP TABLE %s.%s`, schema, tableName))
-		if err != nil {
-			log.Printf("Error creating table: %s", err)
-			http.Error(w, "Failed to create table.", http.StatusBadRequest)
+		if _, err = db.Exec(fmt.Sprintf(`DROP TABLE %s.%s`, schema, tableName)); err != nil {
+			fail(w, http.StatusBadRequest, "error dropping table: %s", err)
 			return
 		}
 
-		_, err = db.Exec(fmt.Sprintf(`DROP SCHEMA %s`, schema))
-		if err != nil {
-			log.Printf("Error creating schema: %s", err)
-			http.Error(w, "Failed to drop schema.", http.StatusBadRequest)
+		if _, err = db.Exec(fmt.Sprintf(`DROP SCHEMA %s`, schema)); err != nil {
+			fail(w, http.StatusBadRequest, "error dropping schema: %s", err)
 			return
 		}
 

--- a/acceptance-tests/apps/mssqlapp/internal/app/fill_db.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/fill_db.go
@@ -16,15 +16,13 @@ func handleFillDatabase(config string) func(w http.ResponseWriter, r *http.Reque
 
 		schema, err := schemaName(r)
 		if err != nil {
-			log.Printf("Schema name error: %s\n", err)
-			http.Error(w, "Schema name error.", http.StatusInternalServerError)
+			fail(w, http.StatusInternalServerError, "schema name error: %s", err)
 			return
 		}
 
 		stmt, err := db.Prepare(fmt.Sprintf(`INSERT INTO %s.%s (%s, %s) VALUES (@p1, REPLICATE(CAST(@p2 AS VARCHAR(max)), 100000))`, schema, tableName, keyColumn, valueColumn))
 		if err != nil {
-			log.Printf("Error preparing statement: %s", err)
-			http.Error(w, "Failed to prepare statement.", http.StatusInternalServerError)
+			fail(w, http.StatusInternalServerError, "error preparing statement: %s", err)
 			return
 		}
 		defer stmt.Close()

--- a/acceptance-tests/apps/mssqlapp/internal/app/set.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/set.go
@@ -17,37 +17,32 @@ func handleSet(config string) func(w http.ResponseWriter, r *http.Request) {
 
 		schema, err := schemaName(r)
 		if err != nil {
-			log.Printf("Schema name error: %s\n", err)
-			http.Error(w, "Schema name error.", http.StatusInternalServerError)
+			fail(w, http.StatusInternalServerError, "schema name error: %s", err)
 			return
 		}
 
 		key, ok := mux.Vars(r)["key"]
 		if !ok {
-			log.Println("Key missing.")
-			http.Error(w, "Key missing.", http.StatusBadRequest)
+			fail(w, http.StatusBadRequest, "key missing: %s", key)
 			return
 		}
 
 		rawValue, err := io.ReadAll(r.Body)
 		if err != nil {
-			log.Printf("Error parsing value: %s", err)
-			http.Error(w, "Failed to parse value.", http.StatusBadRequest)
+			fail(w, http.StatusBadRequest, "error parsing value: %s", err)
 			return
 		}
 
 		stmt, err := db.Prepare(fmt.Sprintf(`INSERT INTO %s.%s (%s, %s) VALUES (@p1, @p2)`, schema, tableName, keyColumn, valueColumn))
 		if err != nil {
-			log.Printf("Error preparing statement: %s", err)
-			http.Error(w, "Failed to prepare statement.", http.StatusInternalServerError)
+			fail(w, http.StatusInternalServerError, "error preparing statement: %s", err)
 			return
 		}
 		defer stmt.Close()
 
 		_, err = stmt.Exec(key, string(rawValue))
 		if err != nil {
-			log.Printf("Error inserting values: %s", err)
-			http.Error(w, "Failed to insert values.", http.StatusBadRequest)
+			fail(w, http.StatusBadRequest, "failed to insert value: %s", err)
 			return
 		}
 

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_test.go
@@ -5,13 +5,14 @@ import (
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("UpgradeMssqlTest", Label("mssql"), func() {
-	When("upgrading broker version", func() {
+	When("upgrading broker version", Label("modern"), func() {
 		It("should continue to work", func() {
 			By("pushing latest released broker version")
 			serviceBroker := brokers.Create(
@@ -94,6 +95,68 @@ var _ = Describe("UpgradeMssqlTest", Label("mssql"), func() {
 
 			got = appTwo.GET("%s/%s", schemaTwo, keyTwo)
 			Expect(got).To(Equal(valueTwo))
+		})
+	})
+
+	When("upgrading broker version", Label("ancient"), func() {
+		It("should continue to work", func() {
+			By("pushing ancient broker version")
+			serviceBroker := brokers.Create(
+				brokers.WithPrefix("csb-mssql"),
+				brokers.WithSourceDir(releasedBuildDir),
+			)
+			defer serviceBroker.Delete()
+
+			By("creating a service")
+			serviceInstance := services.CreateInstance(
+				"csb-azure-mssql",
+				"small-v2",
+				services.WithBroker(serviceBroker),
+			)
+			defer serviceInstance.Delete()
+
+			By("pushing the unstarted app")
+			app := apps.Push(apps.WithApp(apps.MSSQL))
+			defer apps.Delete(app)
+
+			By("binding to the app")
+			serviceInstance.Bind(app)
+
+			By("starting the app")
+			apps.Start(app)
+
+			By("creating a schema")
+			schema := random.Name(random.WithMaxLength(10))
+			app.PUT("", fmt.Sprintf("%s?dbo=false", schema))
+
+			By("setting a key-value")
+			keyOne := random.Hexadecimal()
+			valueOne := random.Hexadecimal()
+			app.PUT(valueOne, "%s/%s", schema, keyOne)
+
+			By("getting the value")
+			got := app.GET("%s/%s", schema, keyOne)
+			Expect(got).To(Equal(valueOne))
+
+			By("pushing the development version of the broker")
+			serviceBroker.UpgradeBroker(developmentBuildDir)
+
+			By("upgrading service instance")
+			serviceInstance.Upgrade()
+
+			By("checking previously written data still accessible")
+			got = app.GET("%s/%s", schema, keyOne)
+			Expect(got).To(Equal(valueOne))
+
+			By("updating the instance plan")
+			serviceInstance.Update("-p", "medium")
+
+			By("checking previously written data still accessible")
+			got = app.GET("%s/%s", schema, keyOne)
+			Expect(got).To(Equal(valueOne))
+
+			By("dropping the schema")
+			app.DELETE(schema)
 		})
 	})
 })


### PR DESCRIPTION
  - In the past it was not possible to create a schema with DBO ownership. This caused problems relating to deleting bindings (if they owned a schema), so it has been fixed. But when testing an upgrade, we need to test from a version that has not been fixed
  - The test app has been modified to be able to create a schema with or without DBO ownership
  - The test app has been updated to reduce duplication in error handling and to log more error details
  - A new "ancient" test has been added, which is a cut down version of the existing test. This tests the upgrade with data, without hitting the binding ownership issues above

[#182413672](https://www.pivotaltracker.com/story/show/182413672)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

