### PR TITLE
test: new upgrade tests for ancient brokerpaks

### DIFF
--- a/azure-mssql-db-failover.yml
+++ b/azure-mssql-db-failover.yml
@@ -124,7 +124,7 @@ provision:
     details: Maximum storage allocated to the database instance in GB
   - field_name: instance_name
     type: string
-    details: Name for your Azure SQL Faileover Group
+    details: Name for your Azure SQL Failover Group
     default: csb-azsql-fog-${request.instance_id}
     constraints:
       maxLength: 63
@@ -144,7 +144,7 @@ provision:
     required: true
   - field_name: read_write_endpoint_failover_policy
     type: string
-    details: Faileover policy (Automatic or Manual)
+    details: Failover policy (Automatic or Manual)
     default: Automatic
     enum:
       Automatic: Automatic

--- a/azure-mssql-failover.yml
+++ b/azure-mssql-failover.yml
@@ -68,7 +68,7 @@ provision:
     details: Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. This property is only settable for General Purpose Serverless databases.
   - field_name: instance_name
     type: string
-    details: Name for your Azure SQL Faileover Group
+    details: Name for your Azure SQL Failover Group
     default: csb-azsql-fog-${request.instance_id}
     constraints:
       maxLength: 63
@@ -91,7 +91,7 @@ provision:
       maxLength: 64
   - field_name: read_write_endpoint_failover_policy
     type: string
-    details: Faileover policy (Automatic or Manual)
+    details: Failover policy (Automatic or Manual)
     default: Automatic
     enum:
       Automatic: Automatic


### PR DESCRIPTION
Ancient brokerpaks don't have all the fixes, so we need to modify some
of the upgrade tests so that we test data retention without hitting
known issues from these old versions.

[#182413672](https://www.pivotaltracker.com/story/show/182413672)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

