### PR TITLE
chore: replace 'interface{}' with 'any'

### DIFF
--- a/acceptance-tests/apps/mongodbapp/internal/app/app.go
+++ b/acceptance-tests/apps/mongodbapp/internal/app/app.go
@@ -48,7 +48,7 @@ func connect(uri string) *mongo.Client {
 	return client
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/apps/mongodbapp/internal/app/fetch_document.go
+++ b/acceptance-tests/apps/mongodbapp/internal/app/fetch_document.go
@@ -31,7 +31,7 @@ func handleFetchDocument(client *mongo.Client) func(w http.ResponseWriter, r *ht
 			return
 		}
 
-		var data interface{}
+		var data any
 		for _, e := range receiver {
 			if e.Key == documentDataKey {
 				data = e.Value

--- a/acceptance-tests/apps/mssqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/app.go
@@ -66,7 +66,7 @@ func schemaName(r *http.Request) (string, error) {
 	}
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/apps/mssqlapp/internal/credentials/config.go
+++ b/acceptance-tests/apps/mssqlapp/internal/credentials/config.go
@@ -42,8 +42,8 @@ func (c Config) String() string {
 	return s.String()
 }
 
-func (c Config) toMap() map[string]interface{} {
-	m := make(map[string]interface{})
+func (c Config) toMap() map[string]any {
+	m := make(map[string]any)
 	v := reflect.ValueOf(c)
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {

--- a/acceptance-tests/apps/mysqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/mysqlapp/internal/app/app.go
@@ -50,7 +50,7 @@ func connect(config *mysql.Config) *sql.DB {
 	return db
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -61,7 +61,7 @@ func schemaName(r *http.Request) (string, error) {
 	}
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/apps/redisapp/internal/app/app.go
+++ b/acceptance-tests/apps/redisapp/internal/app/app.go
@@ -25,7 +25,7 @@ func aliveness(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/cosmosdb_test.go
+++ b/acceptance-tests/cosmosdb_test.go
@@ -18,7 +18,7 @@ var _ = Describe("CosmosDB", Label("cosmosdb"), func() {
 		serviceInstance := services.CreateInstance(
 			"csb-azure-cosmosdb-sql",
 			"small",
-			services.WithParameters(map[string]interface{}{"db_name": databaseName}),
+			services.WithParameters(map[string]any{"db_name": databaseName}),
 		)
 		defer serviceInstance.Delete()
 

--- a/acceptance-tests/helpers/apps/http.go
+++ b/acceptance-tests/helpers/apps/http.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (a *App) GET(format string, s ...interface{}) string {
+func (a *App) GET(format string, s ...any) string {
 	url := a.urlf(format, s...)
 	var data []byte
 
@@ -34,7 +34,7 @@ func (a *App) GET(format string, s ...interface{}) string {
 	return string(data)
 }
 
-func (a *App) PUT(data, format string, s ...interface{}) {
+func (a *App) PUT(data, format string, s ...any) {
 	url := a.urlf(format, s...)
 	fmt.Fprintf(GinkgoWriter, "HTTP PUT: %s\n", url)
 	fmt.Fprintf(GinkgoWriter, "Sending data: %s\n", data)
@@ -46,7 +46,7 @@ func (a *App) PUT(data, format string, s ...interface{}) {
 	Expect(response).To(HaveHTTPStatus(http.StatusCreated, http.StatusOK))
 }
 
-func (a *App) DELETE(format string, s ...interface{}) {
+func (a *App) DELETE(format string, s ...any) {
 	url := a.urlf(format, s...)
 	fmt.Fprintf(GinkgoWriter, "HTTP DELETE: %s\n", url)
 	request, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -57,7 +57,7 @@ func (a *App) DELETE(format string, s ...interface{}) {
 	Expect(response).To(HaveHTTPStatus(http.StatusGone, http.StatusNoContent))
 }
 
-func (a *App) urlf(format string, s ...interface{}) string {
+func (a *App) urlf(format string, s ...any) string {
 	base := a.URL
 	path := fmt.Sprintf(format, s...)
 	switch {

--- a/acceptance-tests/helpers/apps/setenv.go
+++ b/acceptance-tests/helpers/apps/setenv.go
@@ -9,7 +9,7 @@ import (
 
 type EnvVar struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 func (e EnvVar) ValueString() string {

--- a/acceptance-tests/helpers/bindings/credential.go
+++ b/acceptance-tests/helpers/bindings/credential.go
@@ -10,21 +10,21 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (b *Binding) Credential() interface{} {
+func (b *Binding) Credential() any {
 	out, _ := cf.Run("app", "--guid", b.appName)
 	env, _ := cf.Run("curl", fmt.Sprintf("/v3/apps/%s/env", strings.TrimSpace(out)))
 
 	var receiver struct {
-		Services map[string]interface{} `jsonry:"system_env_json.VCAP_SERVICES"`
+		Services map[string]any `jsonry:"system_env_json.VCAP_SERVICES"`
 	}
 	Expect(jsonry.Unmarshal([]byte(env), &receiver)).NotTo(HaveOccurred())
 
 	for _, bindings := range receiver.Services {
-		Expect(bindings).To(BeAssignableToTypeOf([]interface{}{}))
-		for _, bnd := range bindings.([]interface{}) {
-			if n, ok := bnd.(map[string]interface{})["name"]; ok && n == b.name {
+		Expect(bindings).To(BeAssignableToTypeOf([]any{}))
+		for _, bnd := range bindings.([]any) {
+			if n, ok := bnd.(map[string]any)["name"]; ok && n == b.name {
 				Expect(bnd).To(HaveKey("credentials"))
-				return bnd.(map[string]interface{})["credentials"]
+				return bnd.(map[string]any)["credentials"]
 			}
 		}
 	}

--- a/acceptance-tests/helpers/serverpairs/serverpairs.go
+++ b/acceptance-tests/helpers/serverpairs/serverpairs.go
@@ -38,15 +38,15 @@ func NewDatabaseServerPair(metadata environment.Metadata) DatabaseServerPair {
 	}
 }
 
-func (d DatabaseServerPair) PrimaryConfig() interface{} {
+func (d DatabaseServerPair) PrimaryConfig() any {
 	return d.memberConfig(d.PrimaryServer.Name, "westus", d.PrimaryServer.ResourceGroup)
 }
 
-func (d DatabaseServerPair) SecondaryConfig() interface{} {
+func (d DatabaseServerPair) SecondaryConfig() any {
 	return d.memberConfig(d.SecondaryServer.Name, "eastus", d.SecondaryServer.ResourceGroup)
 }
 
-func (d DatabaseServerPair) memberConfig(name, location, rg string) interface{} {
+func (d DatabaseServerPair) memberConfig(name, location, rg string) any {
 	return struct {
 		Name          string `json:"instance_name"`
 		Username      string `json:"admin_username"`
@@ -62,7 +62,7 @@ func (d DatabaseServerPair) memberConfig(name, location, rg string) interface{} 
 	}
 }
 
-func (d DatabaseServerPair) SecondaryResourceGroupConfig() interface{} {
+func (d DatabaseServerPair) SecondaryResourceGroupConfig() any {
 	return struct {
 		InstanceName string `json:"instance_name"`
 		Location     string `json:"location"`
@@ -72,6 +72,6 @@ func (d DatabaseServerPair) SecondaryResourceGroupConfig() interface{} {
 	}
 }
 
-func (d DatabaseServerPair) ServerPairsConfig() interface{} {
-	return map[string]interface{}{d.ServerPairTag: d}
+func (d DatabaseServerPair) ServerPairsConfig() any {
+	return map[string]any{d.ServerPairTag: d}
 }

--- a/acceptance-tests/helpers/servicekeys/get.go
+++ b/acceptance-tests/helpers/servicekeys/get.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (s *ServiceKey) Get(receiver interface{}) {
+func (s *ServiceKey) Get(receiver any) {
 	Expect(reflect.ValueOf(receiver).Kind()).To(Equal(reflect.Ptr), "receiver must be a pointer")
 	out, _ := cf.Run("service-key", s.serviceInstanceName, s.name)
 	start := strings.Index(out, "{")
@@ -18,7 +18,7 @@ func (s *ServiceKey) Get(receiver interface{}) {
 
 	if cf.Version() == cf.VersionV8 {
 		var wrapper struct {
-			Credentials interface{} `json:"credentials"`
+			Credentials any `json:"credentials"`
 		}
 		err := json.Unmarshal(data, &wrapper)
 		Expect(err).NotTo(HaveOccurred())

--- a/acceptance-tests/helpers/services/create.go
+++ b/acceptance-tests/helpers/services/create.go
@@ -88,7 +88,7 @@ func WithBroker(broker *brokers.Broker) Option {
 	}
 }
 
-func WithParameters(parameters interface{}) Option {
+func WithParameters(parameters any) Option {
 	return func(c *config) {
 		switch p := parameters.(type) {
 		case string:

--- a/acceptance-tests/mongodb_test.go
+++ b/acceptance-tests/mongodb_test.go
@@ -18,7 +18,7 @@ var _ = Describe("MongoDB", Label("mongodb"), func() {
 		collectionName := random.Name(random.WithPrefix("collection"))
 		serviceInstance := services.CreateInstance(
 			"csb-azure-mongodb",
-			"small", services.WithParameters(map[string]interface{}{
+			"small", services.WithParameters(map[string]any{
 				"db_name":         databaseName,
 				"collection_name": collectionName,
 				"shard_key":       "_id",

--- a/acceptance-tests/mssql_db_subsume_test.go
+++ b/acceptance-tests/mssql_db_subsume_test.go
@@ -94,15 +94,15 @@ var _ = Describe("MSSQL DB Subsume", Label("mssql-db", "subsume"), func() {
 	})
 })
 
-func subsumeDBParams(resource, serverTag string) interface{} {
-	return map[string]interface{}{
+func subsumeDBParams(resource, serverTag string) any {
+	return map[string]any{
 		"azure_db_id": resource,
 		"server":      serverTag,
 	}
 }
 
-func getMASBServerDetails(tag string) map[string]interface{} {
-	return map[string]interface{}{
+func getMASBServerDetails(tag string) map[string]any {
+	return map[string]any{
 		tag: map[string]string{
 			"server_name":           metadata.PreProvisionedSQLServer,
 			"server_resource_group": metadata.ResourceGroup,

--- a/acceptance-tests/mssql_failover_group_test.go
+++ b/acceptance-tests/mssql_failover_group_test.go
@@ -70,7 +70,7 @@ var _ = Describe("MSSQL Failover Group", Label("mssql"), func() {
 	})
 })
 
-func failoverParameters(instance *services.ServiceInstance) interface{} {
+func failoverParameters(instance *services.ServiceInstance) any {
 	key := instance.CreateServiceKey()
 	defer key.Delete()
 

--- a/acceptance-tests/mssql_fog_db_subsume_test.go
+++ b/acceptance-tests/mssql_fog_db_subsume_test.go
@@ -110,22 +110,22 @@ var _ = Describe("MSSQL Failover Group DB Subsume", Label("mssql-db-failover-gro
 	})
 })
 
-func masbFOGConfig(masbDBName, fogName string) interface{} {
-	return map[string]interface{}{
+func masbFOGConfig(masbDBName, fogName string) any {
+	return map[string]any{
 		"primaryServerName":   metadata.PreProvisionedSQLServer,
 		"primaryDbName":       masbDBName,
 		"secondaryServerName": metadata.PreProvisionedFOGServer,
 		"failoverGroupName":   fogName,
-		"readWriteEndpoint": map[string]interface{}{
+		"readWriteEndpoint": map[string]any{
 			"failoverPolicy":                         "Automatic",
 			"failoverWithDataLossGracePeriodMinutes": 60,
 		},
 	}
 }
 
-func serverPairsConfig(serverPairTag string) interface{} {
-	return map[string]interface{}{
-		serverPairTag: map[string]interface{}{
+func serverPairsConfig(serverPairTag string) any {
+	return map[string]any{
+		serverPairTag: map[string]any{
 			"admin_username": metadata.PreProvisionedSQLUsername,
 			"admin_password": metadata.PreProvisionedSQLPassword,
 			"primary": map[string]string{

--- a/acceptance-tests/mssql_server_and_db_test.go
+++ b/acceptance-tests/mssql_server_and_db_test.go
@@ -90,8 +90,8 @@ type databaseServer struct {
 	Password string `json:"admin_password"`
 }
 
-func (d databaseServer) getMASBServerDetails(tag string) map[string]interface{} {
-	return map[string]interface{}{
+func (d databaseServer) getMASBServerDetails(tag string) map[string]any {
+	return map[string]any{
 		tag: map[string]string{
 			"server_name":           d.Name,
 			"server_resource_group": metadata.ResourceGroup,

--- a/acceptance-tests/mssql_server_pair_and_fog_db_test.go
+++ b/acceptance-tests/mssql_server_pair_and_fog_db_test.go
@@ -96,7 +96,7 @@ var _ = Describe("MSSQL Server Pair and Failover Group DB", Label("mssql-server-
 			"csb-azure-mssql-fog-run-failover",
 			"standard",
 			services.WithBroker(serviceBroker),
-			services.WithParameters(map[string]interface{}{
+			services.WithParameters(map[string]any{
 				"server_pair_name":  serversConfig.ServerPairTag,
 				"server_pairs":      serversConfig.ServerPairsConfig(),
 				"fog_instance_name": fogName,

--- a/acceptance-tests/upgrade/update_and_upgrade_cosmos_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_cosmos_test.go
@@ -27,7 +27,7 @@ var _ = Describe("UpgradeCosmosTest", Label("cosmosdb"), func() {
 				"csb-azure-cosmosdb-sql",
 				"small",
 				services.WithBroker(serviceBroker),
-				services.WithParameters(map[string]interface{}{"db_name": databaseName}),
+				services.WithParameters(map[string]any{"db_name": databaseName}),
 			)
 			defer serviceInstance.Delete()
 

--- a/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
@@ -27,7 +27,7 @@ var _ = Describe("UpgradeMongoTest", Label("mongodb"), func() {
 				"csb-azure-mongodb",
 				"small",
 				services.WithBroker(serviceBroker),
-				services.WithParameters(map[string]interface{}{
+				services.WithParameters(map[string]any{
 					"db_name":         databaseName,
 					"collection_name": collectionName,
 					"shard_key":       "_id",

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_test.go
@@ -326,15 +326,15 @@ type DatabaseServerPairMember struct {
 	ResourceGroup string `json:"resource_group"`
 }
 
-func (d DatabaseServerPair) PrimaryConfig() interface{} {
+func (d DatabaseServerPair) PrimaryConfig() any {
 	return d.memberConfig(d.PrimaryServer.Name, "westus", d.PrimaryServer.ResourceGroup)
 }
 
-func (d DatabaseServerPair) SecondaryConfig() interface{} {
+func (d DatabaseServerPair) SecondaryConfig() any {
 	return d.memberConfig(d.SecondaryServer.Name, "eastus", d.SecondaryServer.ResourceGroup)
 }
 
-func (d DatabaseServerPair) memberConfig(name, location, rg string) interface{} {
+func (d DatabaseServerPair) memberConfig(name, location, rg string) any {
 	return struct {
 		Name          string `json:"instance_name"`
 		Username      string `json:"admin_username"`
@@ -350,7 +350,7 @@ func (d DatabaseServerPair) memberConfig(name, location, rg string) interface{} 
 	}
 }
 
-func (d DatabaseServerPair) SecondaryResourceGroupConfig() interface{} {
+func (d DatabaseServerPair) SecondaryResourceGroupConfig() any {
 	return struct {
 		InstanceName string `json:"instance_name"`
 		Location     string `json:"location"`
@@ -360,6 +360,6 @@ func (d DatabaseServerPair) SecondaryResourceGroupConfig() interface{} {
 	}
 }
 
-func (d DatabaseServerPair) ServerPairsConfig() interface{} {
-	return map[string]interface{}{d.ServerPairTag: d}
+func (d DatabaseServerPair) ServerPairsConfig() any {
+	return map[string]any{d.ServerPairTag: d}
 }

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_test.go
@@ -234,7 +234,7 @@ type databaseServer struct {
 func (d databaseServer) reconfigureCSBWithServerDetails(broker *brokers.Broker) string {
 	serverTag := random.Name(random.WithMaxLength(10))
 
-	creds := map[string]interface{}{
+	creds := map[string]any{
 		serverTag: map[string]string{
 			"server_name":           d.Name,
 			"server_resource_group": metadata.ResourceGroup,
@@ -251,7 +251,7 @@ func (d databaseServer) reconfigureCSBWithServerDetails(broker *brokers.Broker) 
 func (d databaseServer) serverDetails() (string, map[string]any) {
 	serverTag := random.Name(random.WithMaxLength(10))
 
-	creds := map[string]interface{}{
+	creds := map[string]any{
 		serverTag: map[string]string{
 			"server_name":           d.Name,
 			"server_resource_group": metadata.ResourceGroup,

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_failover_group_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_failover_group_test.go
@@ -208,7 +208,7 @@ var _ = Describe("UpgradeMssqlFailoverGroupTest", Label("mssql-failover-group"),
 	})
 })
 
-func failoverParameters(instance *services.ServiceInstance) interface{} {
+func failoverParameters(instance *services.ServiceInstance) any {
 	key := instance.CreateServiceKey()
 	defer key.Delete()
 


### PR DESCRIPTION
Go 1.18 introduced the alternative of 'any' for the rather awkward
'interface{}'. Since this came out we have been using a mixture in this
project. This PR updates code (except generated code) to consistently
use `any` since it's easier to type and to understand.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

