### PR TITLE
chore: SQL-Server provider should use DB transactions

### DIFF
--- a/providers/terraform-provider-csbsqlserver/connector/connector.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector.go
@@ -30,24 +30,19 @@ type Connector struct {
 	port     int
 }
 
-type databaseActor interface {
-	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
-	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
-}
-
 // CreateBinding creates the binding user, adds roles and grants permission to execute store procedures
 // It is idempotent.
 func (c *Connector) CreateBinding(ctx context.Context, username, password string, roles []string) error {
-	return c.withTransaction(func(db databaseActor) error {
-		if err := createUser(ctx, db, username, password); err != nil {
+	return c.withTransaction(func(tx *sql.Tx) error {
+		if err := createUser(ctx, tx, username, password); err != nil {
 			return err
 		}
 
-		if err := addRoles(ctx, db, username, roles); err != nil {
+		if err := addRoles(ctx, tx, username, roles); err != nil {
 			return err
 		}
 
-		if err := grantExec(ctx, db, username); err != nil {
+		if err := grantExec(ctx, tx, username); err != nil {
 			return err
 		}
 
@@ -57,11 +52,11 @@ func (c *Connector) CreateBinding(ctx context.Context, username, password string
 
 // DeleteBinding drops the binding user. It is idempotent.
 func (c *Connector) DeleteBinding(ctx context.Context, username string) error {
-	return c.withTransaction(func(db databaseActor) error {
-		if err := dropUser(ctx, db, username); err != nil {
+	return c.withTransaction(func(tx *sql.Tx) error {
+		if err := dropUser(ctx, tx, username); err != nil {
 			return err
 		}
-		if err := dropLogin(ctx, db, username); err != nil {
+		if err := dropLogin(ctx, tx, username); err != nil {
 			return err
 		}
 
@@ -90,7 +85,7 @@ func (c *Connector) withConnection(callback func(db *sql.DB) error) error {
 	return callback(db)
 }
 
-func (c *Connector) withTransaction(callback func(db databaseActor) error) error {
+func (c *Connector) withTransaction(callback func(tx *sql.Tx) error) error {
 	return c.withConnection(func(db *sql.DB) error {
 		tx, err := db.Begin()
 		if err != nil {
@@ -100,7 +95,7 @@ func (c *Connector) withTransaction(callback func(db databaseActor) error) error
 			_ = tx.Rollback()
 		}()
 
-		if err := callback(db); err != nil {
+		if err := callback(tx); err != nil {
 			return err
 		}
 
@@ -123,6 +118,10 @@ func (c *Connector) connStr() string {
 	return u.String()
 }
 
+type databaseActor interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
 func checkUser(ctx context.Context, db databaseActor, username string) (bool, error) {
 	rows, err := db.QueryContext(ctx, `SELECT NAME FROM sys.database_principals WHERE NAME = @p1 AND TYPE = 'S'`, username)
 	if err != nil {
@@ -132,9 +131,9 @@ func checkUser(ctx context.Context, db databaseActor, username string) (bool, er
 	return rows.Next(), nil
 }
 
-func dropUser(ctx context.Context, db databaseActor, username string) error {
+func dropUser(ctx context.Context, tx *sql.Tx, username string) error {
 	statement := fmt.Sprintf(`DROP USER IF EXISTS [%s]`, username)
-	if _, err := db.ExecContext(ctx, statement); err != nil {
+	if _, err := tx.ExecContext(ctx, statement); err != nil {
 		return fmt.Errorf("error deleting user %q: %w", username, err)
 	}
 
@@ -144,18 +143,18 @@ func dropUser(ctx context.Context, db databaseActor, username string) error {
 // dropLogin drops a legacy login. In the past the brokerpak created a login and
 // then created a user from the login, but this was problematic in a failover because
 // the login did not exist on the replica. See: https://www.pivotaltracker.com/story/show/179168006
-func dropLogin(ctx context.Context, db databaseActor, username string) error {
+func dropLogin(ctx context.Context, tx *sql.Tx, username string) error {
 	// Unfortunately there's no "DROP LOGIN IF EXISTS" and checking for the existence of the login (via sys.sql_logins)
 	// proved unreliable as it worked on the database fake, but not on an Azure database. So we just attempt the operation
 	// and ignore any error. The issue with checking for the "right" error is that any check would be fragile if there were
 	// future changes to the message, SQLState, etc... and the benefit was not considered to be worth the risk
-	_, _ = db.ExecContext(ctx, fmt.Sprintf(`DROP LOGIN [%s]`, username))
+	_, _ = tx.ExecContext(ctx, fmt.Sprintf(`DROP LOGIN [%s]`, username))
 
 	return nil
 }
 
-func createUser(ctx context.Context, db databaseActor, username, password string) error {
-	ok, err := checkUser(ctx, db, username)
+func createUser(ctx context.Context, tx *sql.Tx, username, password string) error {
+	ok, err := checkUser(ctx, tx, username)
 	switch {
 	case err != nil:
 		return err
@@ -164,17 +163,17 @@ func createUser(ctx context.Context, db databaseActor, username, password string
 	}
 
 	statement := fmt.Sprintf(`CREATE USER [%s] with PASSWORD='%s'`, username, password)
-	if _, err := db.ExecContext(ctx, statement); err != nil {
+	if _, err := tx.ExecContext(ctx, statement); err != nil {
 		return fmt.Errorf("error creating user %q: %w", username, err)
 	}
 
 	return nil
 }
 
-func addRoles(ctx context.Context, db databaseActor, username string, roles []string) error {
+func addRoles(ctx context.Context, tx *sql.Tx, username string, roles []string) error {
 	for _, role := range roles {
 		statement := fmt.Sprintf(`ALTER ROLE %s ADD MEMBER [%s]`, role, username)
-		if _, err := db.ExecContext(ctx, statement); err != nil {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("error adding user %q to role %q: %w", username, role, err)
 		}
 	}
@@ -182,9 +181,9 @@ func addRoles(ctx context.Context, db databaseActor, username string, roles []st
 	return nil
 }
 
-func grantExec(ctx context.Context, db databaseActor, username string) error {
+func grantExec(ctx context.Context, tx *sql.Tx, username string) error {
 	statement := fmt.Sprintf(`GRANT EXEC TO [%s]`, username)
-	if _, err := db.ExecContext(ctx, statement); err != nil {
+	if _, err := tx.ExecContext(ctx, statement); err != nil {
 		return fmt.Errorf("error granting exec to user %q: %w", username, err)
 	}
 

--- a/providers/terraform-provider-csbsqlserver/connector/connector.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector.go
@@ -72,7 +72,7 @@ func (c *Connector) ReadBinding(ctx context.Context, username string) (result bo
 	})
 }
 
-func (c *Connector) withConnection(callback func(db *sql.DB) error) error {
+func (c *Connector) withConnection(callback func(*sql.DB) error) error {
 	db, err := sql.Open("sqlserver", c.connStr())
 	if err != nil {
 		return fmt.Errorf("error connecting to database %q on %q port %d with user %q: %w", c.database, c.server, c.port, c.username, err)
@@ -85,7 +85,7 @@ func (c *Connector) withConnection(callback func(db *sql.DB) error) error {
 	return callback(db)
 }
 
-func (c *Connector) withTransaction(callback func(tx *sql.Tx) error) error {
+func (c *Connector) withTransaction(callback func(*sql.Tx) error) error {
 	return c.withConnection(func(db *sql.DB) error {
 		tx, err := db.Begin()
 		if err != nil {


### PR DESCRIPTION
It's good practice to use database transactions when performing related
database tasks, and this change introduces transactions for creating and
deleting the binding, so that the operation should either happen (or not
happen) atomically

[#182986768](https://www.pivotaltracker.com/story/show/182986768)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

