### PR TITLE
fix: a problem when logging the secret value in terraform-provider-csbmssqldbrunfailover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ providers/terraform-provider-csbsqlserver/cloudfoundry.org
 providers/terraform-provider-csbmssqldbrunfailover/cloudfoundry.org
 cloud-service-broker
 .idea
+csbmssqldbrunfailover.test

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,6 +1,6 @@
 ## Release notes for next release:
 
 ### New feature:
-- Client Secret field validation in failover service: We introduce a less restrictive validation. The main validation is on the supplier's side, and we just check if the field is empty or too long.
+- **Failover service parameters validation is more flexible:** Previously, the validation of the parameters was carried out in a more restrictive way adding rigidity to the admitted values. With this change, the main validation is on the supplier side, and we only check if the field is empty.
 ### Fix:
-- The value of the Client Secret is considered a sensible field. We avoid logging its value in plain text in our custom terraform provider csbmssqldbrunfailover.
+- **Failover service client secret parameter is no longer exposed:** The value of the Client Secret is considered a sensible field. We avoid logging its value in plain text in our custom terraform provider csbmssqldbrunfailover.

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,5 +1,6 @@
 ## Release notes for next release:
 
 ### New feature:
-
+- Client Secret field validation: We introduce a less restrictive validation. The main validation is on the supplier's side, and we just check if the field is empty or too long.
 ### Fix:
+- The value of the Client Secret is considered a sensible field. We avoid logging its value in plain text in our custom terraform provider csbmssqldbrunfailover.

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,6 +1,6 @@
 ## Release notes for next release:
 
 ### New feature:
-- Client Secret field validation: We introduce a less restrictive validation. The main validation is on the supplier's side, and we just check if the field is empty or too long.
+- Client Secret field validation in failover service: We introduce a less restrictive validation. The main validation is on the supplier's side, and we just check if the field is empty or too long.
 ### Fix:
 - The value of the Client Secret is considered a sensible field. We avoid logging its value in plain text in our custom terraform provider csbmssqldbrunfailover.

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,6 +1,7 @@
 ## Release notes for next release:
 
 ### New feature:
-- **Failover service parameters validation is more flexible:** Previously, the validation of the parameters was carried out in a more restrictive way adding rigidity to the admitted values. With this change, the main validation is on the supplier side, and we only check if the field is empty.
+
 ### Fix:
 - **Failover service client secret parameter is no longer exposed:** The value of the Client Secret is considered a sensible field. We avoid logging its value in plain text in our custom terraform provider csbmssqldbrunfailover.
+- **Failover service parameters validation is more flexible:** Previously, the validation of the parameters was carried out in a more restrictive way adding rigidity to the admitted values. With this change, the main validation is on the supplier side, and we only check if the field is empty.

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/config.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/config.go
@@ -1,45 +1,15 @@
 package csbmssqldbrunfailover
 
 import (
-	"regexp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const (
-	maxLengthClientSecret = 1024
-)
-
-var (
-	identifierRegexp = regexp.MustCompile(`^[\w_.-]{1,64}$`)
-)
-
-// getIdentifier gets a string configuration value and validates that it's
-// a valid identifier
+// getIdentifier gets a string configuration value and validates that it's a valid identifier
 func getIdentifier(d *schema.ResourceData, key string) (string, diag.Diagnostics) {
-	// We rely on Terraform to supply the correct types, and it's ok panic if this contract is broken
 	s := d.Get(key).(string)
-	if !identifierRegexp.MatchString(s) {
-		return "", diag.Errorf("invalid value %q for identifier %q, validation expression is: %s", s, key, identifierRegexp.String())
-	}
-
-	return s, nil
-}
-
-func getClientSecret(d *schema.ResourceData) (string, diag.Diagnostics) {
-	s := d.Get(azureClientSecretKey).(string)
-
 	if s == "" {
-		return "", diag.Errorf("empty client secret value for %q", azureClientSecretKey)
-	}
-
-	if len(s) > maxLengthClientSecret {
-		return "", diag.Errorf(
-			"invalid client secret value for %q, exceeds the maximum number of bytes allowed %d",
-			azureClientSecretKey,
-			maxLengthClientSecret,
-		)
+		return "", diag.Errorf("empty value for identifier %q", key)
 	}
 
 	return s, nil

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/csbmssqldbrunfailover_suite_test.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/csbmssqldbrunfailover_suite_test.go
@@ -1,6 +1,7 @@
 package csbmssqldbrunfailover_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -10,4 +11,44 @@ import (
 func TestCSBSQLDBRunFailoverServer(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CSB MSSQL Db Run Failover Terraform Provider Suite")
+}
+
+func generateHCLContent(
+	azureTenantID,
+	azureClientID,
+	azureClientSecret,
+	azureSubscriptionID,
+	resourceGroup,
+	partnerServerResourceGroup,
+	serverName,
+	partnerServerName,
+	failoverGroup string,
+) string {
+	const hcl = `
+provider "csbmssqldbrunfailover" {
+  azure_tenant_id       = "%s"
+  azure_client_id       = "%s"
+  azure_client_secret   = "%s"
+  azure_subscription_id = "%s"
+}
+
+resource "csbmssqldbrunfailover_failover" "failover" {
+  resource_group                = "%s"
+  partner_server_resource_group = "%s"
+  server_name                   = "%s"
+  partner_server_name           = "%s"
+  failover_group                = "%s"
+}`
+	return fmt.Sprintf(
+		hcl,
+		azureTenantID,
+		azureClientID,
+		azureClientSecret,
+		azureSubscriptionID,
+		resourceGroup,
+		partnerServerResourceGroup,
+		serverName,
+		partnerServerName,
+		failoverGroup,
+	)
 }

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider.go
@@ -31,6 +31,8 @@ func Provider() *schema.Provider {
 			azureClientSecretKey: {
 				Type:     schema.TypeString,
 				Required: true,
+				// Set the Sensitive flag so output is hidden in the TF UI
+				Sensitive: true,
 			},
 			azureSubscriptionIDKey: {
 				Type:     schema.TypeString,

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider.go
@@ -64,7 +64,7 @@ func configure(_ context.Context, d *schema.ResourceData) (any, diag.Diagnostics
 			return
 		},
 		func() (diags diag.Diagnostics) {
-			azureClientSecret, diags = getClientSecret(d)
+			azureClientSecret, diags = getIdentifier(d, azureClientSecretKey)
 			return
 		},
 		func() (diags diag.Diagnostics) {

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider_test.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider_test.go
@@ -2,7 +2,6 @@ package csbmssqldbrunfailover_test
 
 import (
 	"regexp"
-	"strings"
 
 	"csbbrokerpakazure/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover"
 
@@ -69,54 +68,48 @@ var _ = Describe("Provider Configuration", func() {
 		},
 		Entry(
 			"tenant id",
-			func() { azureTenantID = "not valid" },
-			`invalid value "not valid" for identifier "azure_tenant_id"`,
+			func() { azureTenantID = "" },
+			`empty value for identifier "azure_tenant_id"`,
 		),
 		Entry(
 			"client id",
 			func() { azureClientID = "" },
-			`invalid value "" for identifier "azure_client_id"`,
+			`empty value for identifier "azure_client_id"`,
 		),
 		Entry(
 			"client secret empty",
 			func() { azureClientSecret = "" },
-			`empty client secret value for "azure_client_secret"`,
-		),
-		Entry(
-
-			"client secret too long",
-			func() { azureClientSecret = strings.Repeat("x", 1025) },
-			`invalid client secret value for "azure_client_secret", exceeds the maximum number of bytes allowed 1024`,
+			`empty value for identifier "azure_client_secret"`,
 		),
 		Entry(
 			"subscription id",
-			func() { azureSubscriptionID = "&&" },
-			`invalid value "&&" for identifier "azure_subscription_id"`,
+			func() { azureSubscriptionID = "" },
+			`empty value for identifier "azure_subscription_id"`,
 		),
 		Entry(
 			"resource group",
-			func() { resourceGroup = "not valid" },
-			`invalid value "not valid" for identifier "resource_group"`,
+			func() { resourceGroup = "" },
+			`empty value for identifier "resource_group"`,
 		),
 		Entry(
 			"partner server resource group",
-			func() { partnerServerResourceGroup = "not valid" },
-			`invalid value "not valid" for identifier "partner_server_resource_group"`,
+			func() { partnerServerResourceGroup = "" },
+			`empty value for identifier "partner_server_resource_group"`,
 		),
 		Entry(
 			"server name",
-			func() { serverName = "&&" },
-			`invalid value "&&" for identifier "server_name"`,
+			func() { serverName = "" },
+			`empty value for identifier "server_name"`,
 		),
 		Entry(
 			"partner server name",
-			func() { partnerServerName = "&&" },
-			`invalid value "&&" for identifier "partner_server_name"`,
+			func() { partnerServerName = "" },
+			`empty value for identifier "partner_server_name"`,
 		),
 		Entry(
 			"failover group",
-			func() { failoverGroup = "&&" },
-			`invalid value "&&" for identifier "failover_group"`,
+			func() { failoverGroup = "" },
+			`empty value for identifier "failover_group"`,
 		),
 	)
 })

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider_test.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/provider_test.go
@@ -1,8 +1,8 @@
 package csbmssqldbrunfailover_test
 
 import (
-	"fmt"
 	"regexp"
+	"strings"
 
 	"csbbrokerpakazure/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover"
 
@@ -43,21 +43,7 @@ var _ = Describe("Provider Configuration", func() {
 		func(cb func(), expectError string) {
 			cb()
 
-			hcl := fmt.Sprintf(`
-				provider "csbmssqldbrunfailover" {
-				  azure_tenant_id       = "%s"
-				  azure_client_id       = "%s"
-				  azure_client_secret   = "%s"
-				  azure_subscription_id = "%s"
-				}
-				
-				resource "csbmssqldbrunfailover_failover" "failover" {
-				  resource_group                = "%s"
-				  partner_server_resource_group = "%s"
-				  server_name                   = "%s"
-				  partner_server_name           = "%s"
-				  failover_group                = "%s"
-				}`,
+			hcl := generateHCLContent(
 				azureTenantID,
 				azureClientID,
 				azureClientSecret,
@@ -81,14 +67,56 @@ var _ = Describe("Provider Configuration", func() {
 				}},
 			})
 		},
-		Entry("tenant id", func() { azureTenantID = "not valid" }, `invalid value "not valid" for identifier "azure_tenant_id"`),
-		Entry("client id", func() { azureClientID = "" }, `invalid value "" for identifier "azure_client_id"`),
-		Entry("client secret", func() { azureClientSecret = "invalid value" }, `invalid value "invalid value" for identifier "azure_client_secret"`),
-		Entry("subscription id", func() { azureSubscriptionID = "&&" }, `invalid value "&&" for identifier "azure_subscription_id"`),
-		Entry("resource group", func() { resourceGroup = "not valid" }, `invalid value "not valid" for identifier "resource_group"`),
-		Entry("partner server resource group", func() { partnerServerResourceGroup = "not valid" }, `invalid value "not valid" for identifier "partner_server_resource_group"`),
-		Entry("server name", func() { serverName = "&&" }, `invalid value "&&" for identifier "server_name"`),
-		Entry("partner server name", func() { partnerServerName = "&&" }, `invalid value "&&" for identifier "partner_server_name"`),
-		Entry("failover group", func() { failoverGroup = "&&" }, `invalid value "&&" for identifier "failover_group"`),
+		Entry(
+			"tenant id",
+			func() { azureTenantID = "not valid" },
+			`invalid value "not valid" for identifier "azure_tenant_id"`,
+		),
+		Entry(
+			"client id",
+			func() { azureClientID = "" },
+			`invalid value "" for identifier "azure_client_id"`,
+		),
+		Entry(
+			"client secret empty",
+			func() { azureClientSecret = "" },
+			`empty client secret value for "azure_client_secret"`,
+		),
+		Entry(
+
+			"client secret too long",
+			func() { azureClientSecret = strings.Repeat("x", 1025) },
+			`invalid client secret value for "azure_client_secret", exceeds the maximum number of bytes allowed 1024`,
+		),
+		Entry(
+			"subscription id",
+			func() { azureSubscriptionID = "&&" },
+			`invalid value "&&" for identifier "azure_subscription_id"`,
+		),
+		Entry(
+			"resource group",
+			func() { resourceGroup = "not valid" },
+			`invalid value "not valid" for identifier "resource_group"`,
+		),
+		Entry(
+			"partner server resource group",
+			func() { partnerServerResourceGroup = "not valid" },
+			`invalid value "not valid" for identifier "partner_server_resource_group"`,
+		),
+		Entry(
+			"server name",
+			func() { serverName = "&&" },
+			`invalid value "&&" for identifier "server_name"`,
+		),
+		Entry(
+			"partner server name",
+			func() { partnerServerName = "&&" },
+			`invalid value "&&" for identifier "partner_server_name"`,
+		),
+		Entry(
+			"failover group",
+			func() { failoverGroup = "&&" },
+			`invalid value "&&" for identifier "failover_group"`,
+		),
 	)
 })

--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/resource_run_failover_test.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/resource_run_failover_test.go
@@ -64,21 +64,7 @@ var _ = Describe("resource_run_failover resource", Ordered, Label("acceptance"),
 	})
 
 	It("should failover to the secondary database", func() {
-		hcl := fmt.Sprintf(`
-				provider "csbmssqldbrunfailover" {
-				  azure_tenant_id       = "%s"
-				  azure_client_id       = "%s"
-				  azure_client_secret   = "%s"
-				  azure_subscription_id = "%s"
-				}
-				
-				resource "csbmssqldbrunfailover_failover" "failover" {
-				  resource_group                = "%s"
-				  partner_server_resource_group = "%s"
-				  server_name                   = "%s"
-				  partner_server_name           = "%s"
-				  failover_group                = "%s"
-				}`,
+		hcl := generateHCLContent(
 			azureTenantID,
 			azureClientID,
 			azureClientSecret,


### PR DESCRIPTION
Fix a problem when logging the secret value.
We remove the regex introducing less restrictive validations. The validation is on the supplier’s side and we just check if the field is empty or too long.

[#183032358](https://www.pivotaltracker.com/story/show/183032358)
[#183032253](https://www.pivotaltracker.com/story/show/183032253)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

