### PR TITLE
Revert "chore: "make run" should target current platform"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,7 @@ $(IAAS)-services-*.brokerpak: *.yml terraform/*/*.tf ./providers/terraform-provi
 	$(RUN_CSB) pak build
 
 .PHONY: run
-run: arm-subscription-id arm-tenant-id arm-client-id arm-client-secret ## start broker with this brokerpak
-	$(RUN_CSB) pak build --target current
+run: build arm-subscription-id arm-tenant-id arm-client-id arm-client-secret ## start broker with this brokerpak
 	$(RUN_CSB) serve
 
 .PHONY: catalog


### PR DESCRIPTION
Reverts cloudfoundry/csb-brokerpak-azure#321