### PR TITLE
test: increase broker app memory

### DIFF
--- a/acceptance-tests/helpers/brokers/manifest.go
+++ b/acceptance-tests/helpers/brokers/manifest.go
@@ -16,7 +16,7 @@ func newManifest(opts ...manifestOption) string {
 		Applications: []applicationModel{
 			{
 				Command:     "./cloud-service-broker serve",
-				Memory:      "500MB",
+				Memory:      "750MB",
 				Disk:        "2G",
 				Buildpacks:  []string{"binary_buildpack"},
 				RandomRoute: true,


### PR DESCRIPTION
I'm seeing a number of intermittent failures when starting the broker app
like:
```
2022-08-31T03:11:33.90+0000 [APP/PROC/WEB/0] ERR panic: error loading brokerpaks: error extracting versioned terraform binary: couldn't extract file "bin/linux/amd64/0.14.11/terraform": copy couldn't copy data: write /home/vcap/tmp/brokerpak1632791266/versions/0.14.11/terraform: cannot allocate memory
```
Hopefully a bit more memory will make them go away.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

