### PR TITLE
test: fix integration tests - add service-image

### DIFF
--- a/integration-tests/integration_test_suite_test.go
+++ b/integration-tests/integration_test_suite_test.go
@@ -34,6 +34,7 @@ var _ = BeforeSuite(func() {
 		testframework.PathToBrokerPack(),
 		mockTerraform,
 		GinkgoWriter,
+		"service-images",
 	)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(broker.Start(GinkgoWriter, []string{


### PR DESCRIPTION
integration tests were failing as we were not copying the service
image across when building the brokerpak.

[#183058257](https://www.pivotaltracker.com/story/show/183058257)

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

