### PR TITLE
feat: mark sensitive values in var inputs and outputs

### DIFF
--- a/terraform/azure-cosmosdb/provision-cosmosdb-sql.tf
+++ b/terraform/azure-cosmosdb/provision-cosmosdb-sql.tf
@@ -15,10 +15,22 @@
 variable "instance_name" { type = string }
 variable "resource_group" { type = string }
 variable "db_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "failover_locations" { type = list(string) }
 variable "location" { type = string }
 variable "ip_range_filter" { type = string }

--- a/terraform/azure-eventhubs/azure-eventhubs-bind.tf
+++ b/terraform/azure-eventhubs/azure-eventhubs-bind.tf
@@ -15,10 +15,22 @@
 variable "eventhub_rg_name" { type = string }
 variable "namespace_name" { type = string }
 variable "eventhub_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "skip_provider_registration" { type = bool }
 
 terraform {

--- a/terraform/azure-eventhubs/azure-eventhubs.tf
+++ b/terraform/azure-eventhubs/azure-eventhubs.tf
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 variable "instance_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "resource_group" { type = string }
 variable "location" { type = string }
 variable "sku" { type = string }

--- a/terraform/azure-mongodb/azure-mongodb.tf
+++ b/terraform/azure-mongodb/azure-mongodb.tf
@@ -14,10 +14,22 @@
 
 variable "resource_group" { type = string }
 variable "instance_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "account_name" { type = string }
 variable "db_name" { type = string }
 variable "collection_name" { type = string }

--- a/terraform/azure-mssql-db-failover/run-failover/run-failover-providers.tf
+++ b/terraform/azure-mssql-db-failover/run-failover/run-failover-providers.tf
@@ -1,7 +1,19 @@
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 
 provider "csbmssqldbrunfailover" {
   azure_tenant_id       = var.azure_tenant_id

--- a/terraform/azure-mssql-db/bind/mssql-bind-variables.tf
+++ b/terraform/azure-mssql-db/bind/mssql-bind-variables.tf
@@ -16,6 +16,12 @@ variable "mssql_db_name" { type = string }
 variable "mssql_hostname" { type = string }
 variable "mssql_port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type = string
+  sensitive = true
+}
 variable "server" { type = string }
-variable "server_credentials" { type = map(any) }
+variable "server_credentials" { 
+  type = map(any)
+  sensitive = true
+}

--- a/terraform/azure-mssql-db/provision/mssql-db-providers.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-providers.tf
@@ -12,10 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
-variable "azure_tenant_id" { type = string }
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
 variable "skip_provider_registration" { type = bool }
 
 provider "azurerm" {

--- a/terraform/azure-mssql-db/provision/mssql-db-variables.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-variables.tf
@@ -1,6 +1,9 @@
 variable "db_name" { type = string }
 variable "server" { type = string }
-variable "server_credentials" { type = map(any) }
+variable "server_credentials" { 
+  type = map(any) 
+  sensitive = true
+}
 variable "labels" { type = map(any) }
 variable "sku_name" { type = string }
 variable "cores" { type = number }

--- a/terraform/azure-mssql-failover/provision-mssql-failover.tf
+++ b/terraform/azure-mssql-failover/provision-mssql-failover.tf
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 variable "instance_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "resource_group" { type = string }
 variable "db_name" { type = string }
 variable "location" { type = string }

--- a/terraform/azure-mssql-server/mssql-server-provision.tf
+++ b/terraform/azure-mssql-server/mssql-server-provision.tf
@@ -13,13 +13,28 @@
 # limitations under the License.
 
 variable "instance_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "resource_group" { type = string }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type = string
+  sensitive = true
+}
 variable "location" { type = string }
 variable "labels" { type = map(any) }
 variable "authorized_network" { type = string }
@@ -126,4 +141,7 @@ output "password" {
   sensitive = true
 }
 output "databaseLogin" { value = local.admin_username }
-output "databaseLoginPassword" { value = local.admin_password }
+output "databaseLoginPassword" {
+  value = local.admin_password
+  sensitive = true
+}

--- a/terraform/azure-mssql/bind-mssql.tf
+++ b/terraform/azure-mssql/bind-mssql.tf
@@ -16,7 +16,10 @@ variable "mssql_db_name" { type = string }
 variable "mssql_hostname" { type = string }
 variable "mssql_port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type = string
+  sensitive = true
+}
 
 terraform {
   required_providers {

--- a/terraform/azure-mssql/provision-mssql.tf
+++ b/terraform/azure-mssql/provision-mssql.tf
@@ -16,10 +16,22 @@ variable "instance_name" { type = string }
 variable "resource_group" { type = string }
 variable "db_name" { type = string }
 variable "location" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "labels" { type = map(any) }
 variable "sku_name" { type = string }
 variable "cores" { type = number }

--- a/terraform/azure-mysql/bind-mysql.tf
+++ b/terraform/azure-mysql/bind-mysql.tf
@@ -16,7 +16,10 @@ variable "mysql_db_name" { type = string }
 variable "mysql_hostname" { type = string }
 variable "mysql_port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type = string
+  sensitive = true
+}
 variable "use_tls" { type = bool }
 
 provider "mysql" {
@@ -56,7 +59,10 @@ locals {
   username = format("%s@%s", random_string.username.result, var.mysql_hostname)
 }
 output "username" { value = local.username }
-output "password" { value = random_password.password.result }
+output "password" {
+  value = random_password.password.result
+  sensitive = true
+}
 output "uri" {
   value = format("%s://%s:%s@%s:%d/%s",
     "mysql",
@@ -65,6 +71,7 @@ output "uri" {
     var.mysql_hostname,
     var.mysql_port,
   var.mysql_db_name)
+  sensitive = true
 }
 output "jdbcUrl" {
   value = format("jdbc:%s://%s:%s/%s?user=%s\u0026password=%s\u0026verifyServerCertificate=true\u0026useSSL=%v\u0026requireSSL=%v\u0026serverTimezone=GMT",
@@ -76,4 +83,6 @@ output "jdbcUrl" {
     random_password.password.result,
     var.use_tls,
   var.use_tls)
-}  
+  sensitive = true
+}
+

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -14,10 +14,22 @@
 
 variable "instance_name" { type = string }
 variable "resource_group" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "db_name" { type = string }
 variable "mysql_version" { type = string }
 variable "location" { type = string }
@@ -223,7 +235,10 @@ resource "azurerm_private_endpoint" "private_endpoint" {
 output "name" { value = azurerm_mysql_database.instance-db.name }
 output "hostname" { value = azurerm_mysql_server.instance.fqdn }
 output "port" { value = 3306 }
-output "username" { value = format("%s@%s", azurerm_mysql_server.instance.administrator_login, azurerm_mysql_server.instance.name) }
+output "username" { 
+  sensitive = true
+  value = format("%s@%s", azurerm_mysql_server.instance.administrator_login, azurerm_mysql_server.instance.name) 
+}
 output "password" {
   value     = azurerm_mysql_server.instance.administrator_login_password
   sensitive = true

--- a/terraform/azure-postgres/postgres-provision.tf
+++ b/terraform/azure-postgres/postgres-provision.tf
@@ -19,10 +19,22 @@ variable "location" { type = string }
 variable "labels" { type = map(any) }
 variable "storage_gb" { type = number }
 variable "resource_group" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "postgres_version" { type = string }
 variable "sku_name" { type = string }
 variable "authorized_network" { type = string }

--- a/terraform/azure-postgres/postgresql-bind.tf
+++ b/terraform/azure-postgres/postgresql-bind.tf
@@ -16,7 +16,10 @@ variable "db_name" { type = string }
 variable "hostname" { type = string }
 variable "port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type = string
+  sensitive = true
+}
 variable "use_tls" { type = bool }
 
 terraform {
@@ -85,7 +88,10 @@ locals {
   username = format("%s@%s", random_string.username.result, var.hostname)
 }
 output "username" { value = local.username }
-output "password" { value = random_password.password.result }
+output "password" {
+  value = random_password.password.result
+  sensitive = true
+}
 output "uri" {
   value = format("%s://%s:%s@%s:%d/%s",
     "postgresql",
@@ -94,6 +100,7 @@ output "uri" {
     var.hostname,
     var.port,
   var.db_name)
+  sensitive = true 
 }
 output "jdbcUrl" {
   value = format("jdbc:%s://%s:%s/%s?user=%s\u0026password=%s\u0026verifyServerCertificate=true\u0026useSSL=%v\u0026requireSSL=false\u0026serverTimezone=GMT",
@@ -104,4 +111,5 @@ output "jdbcUrl" {
     local.username,
     random_password.password.result,
   var.use_tls)
+  sensitive = true 
 }

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 variable "resource_group" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "sku_name" { type = string }
 variable "family" { type = string }
 variable "capacity" { type = string }

--- a/terraform/azure-resource-group/resource-group-provision.tf
+++ b/terraform/azure-resource-group/resource-group-provision.tf
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 variable "instance_name" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 variable "location" { type = string }
 variable "labels" { type = map(any) }
 variable "skip_provider_registration" { type = bool }

--- a/terraform/azure-storage/account-provision.tf
+++ b/terraform/azure-storage/account-provision.tf
@@ -18,10 +18,22 @@ variable "replication_type" { type = string }
 variable "location" { type = string }
 variable "labels" { type = map(any) }
 variable "resource_group" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_tenant_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_subscription_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_id" {
+  type = string
+  sensitive = true
+}
+variable "azure_client_secret" {
+  type = string
+  sensitive = true
+}
 # variable authorized_network {type = string}
 variable "skip_provider_registration" { type = bool }
 variable "authorized_networks" { type = list(string) }


### PR DESCRIPTION
terraform will display sensitive values in debug logs if not instructured to redact them. This adds redaction to possible sources for credential leaks in the tf input / output data.

[ #183474479 ]

### Checklist:

~* [ ] Have you added Release Notes in the docs repositories?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

