### PR TITLE
feat: Redis - Mark brokerpak plans as deprecated

### DIFF
--- a/acceptance-tests/redis_test.go
+++ b/acceptance-tests/redis_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("Redis", Label("redis"), func() {
 	It("can be accessed by an app", func() {
 		By("creating a service instance")
-		serviceInstance := services.CreateInstance("csb-azure-redis", "small")
+		serviceInstance := services.CreateInstance("csb-azure-redis", "deprecated-small")
 		defer serviceInstance.Delete()
 
 		By("pushing the unstarted app twice")

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -73,7 +73,7 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			Expect(appTwo.GET(key1)).To(Equal(value1))
 
 			By("updating the instance plan")
-			serviceInstance.Update("-p", "medium")
+			serviceInstance.Update("-p", "deprecated-medium")
 
 			By("checking it still works")
 			key3 := random.Hexadecimal()

--- a/azure-redis.yml
+++ b/azure-redis.yml
@@ -23,10 +23,10 @@ support_url: https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/
 tags: [azure, redis, preview]
 plan_updateable: true
 plans:
-- name: small
+- name: deprecated-small
   id: 6b9ca24e-1dec-4e6f-8c8a-dc6e11ab5bef
-  description: 'A basic plan with 1GB cache and no failover. High Availability is not provided, update WILL result in loss of data.'
-  display_name: "Small"
+  description: 'Deprecated - A basic plan with 1GB cache and no failover. High Availability is not provided, update WILL result in loss of data.'
+  display_name: "Deprecated - Small"
   properties:
     sku_name: Basic
     family: C
@@ -34,10 +34,10 @@ plans:
     capacity: 1
     tls_min_version: "1.2"
     firewall_rules: []
-- name: medium
+- name: deprecated-medium
   id: 6b272c43-2116-4483-9a99-de9262c0a7d6
-  description: 'A v4 Redis basic plan with 6GB cache and no failover. High Availability is not provided, update WILL result in loss of data.'
-  display_name: "Medium"
+  description: 'Deprecated - A v4 Redis basic plan with 6GB cache and no failover. High Availability is not provided, update WILL result in loss of data.'
+  display_name: "Deprecated - Medium"
   properties:
     sku_name: Basic
     family: C
@@ -45,10 +45,10 @@ plans:
     capacity: 3
     tls_min_version: "1.2"
     firewall_rules: []
-- name: large
+- name: deprecated-large
   id: c3e34abc-a820-457c-b723-1c342ef42c50
-  description: 'A v4 Redis basic plan with 26GB cache and no failover. High Availability is not provided, update WILL result in loss of data.'
-  display_name: "Large"
+  description: 'Deprecated - A v4 Redis basic plan with 26GB cache and no failover. High Availability is not provided, update WILL result in loss of data.'
+  display_name: "Deprecated - Large"
   properties:
     sku_name: Basic
     family: C
@@ -56,10 +56,10 @@ plans:
     capacity: 5
     firewall_rules: []
     tls_min_version: "1.2"
-- name: ha-small
+- name: deprecated-ha-small
   id: d27a8e60-3724-49d1-b668-44b03d99b3b3
-  description: 'A v4 Redis standard plan with 1GB cache with high availability and no failover.'
-  display_name: "High Availability Small"
+  description: 'Deprecated - A v4 Redis standard plan with 1GB cache with high availability and no failover.'
+  display_name: "Deprecated - High Availability Small"
   properties:
     sku_name: Standard
     family: C
@@ -67,10 +67,10 @@ plans:
     capacity: 1
     firewall_rules: []
     tls_min_version: "1.2"
-- name: ha-medium
+- name: deprecated-ha-medium
   id: 421b932a-b86f-48a3-97e4-64bb13d3ec13
-  description: 'A v4 Redis standard plan with 6GB cache with high availability and no failover.'
-  display_name: "High Availability Medium"
+  description: 'Deprecated - A v4 Redis standard plan with 6GB cache with high availability and no failover.'
+  display_name: "Deprecated - High Availability Medium"
   properties:
     sku_name: Standard
     family: C
@@ -78,10 +78,10 @@ plans:
     capacity: 3
     firewall_rules: []
     tls_min_version: "1.2"
-- name: ha-large
+- name: deprecated-ha-large
   id: e919b281-9661-465d-82cf-0a0a6e1f195a
-  description: 'A v4 Redis standard plan with 26GB cache with high availability and no failover.'
-  display_name: "High Availability Large"
+  description: 'Deprecated - A v4 Redis standard plan with 26GB cache with high availability and no failover.'
+  display_name: "Deprecated - High Availability Large"
   properties:
     sku_name: Standard
     family: C
@@ -89,10 +89,10 @@ plans:
     capacity: 5
     firewall_rules: []
     tls_min_version: "1.2"
-- name: ha-P1
+- name: deprecated-ha-P1
   id: 2a63e092-ab5c-4804-abd6-2d951240f0f6
-  description: "A v4 Redis High Availability plan with 1GB cache and no failover"
-  display_name: "High Availability P1"
+  description: "Deprecated - A v4 Redis High Availability plan with 1GB cache and no failover"
+  display_name: "Deprecated - High Availability P1"
   properties:
     sku_name: Premium
     family: P

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -21,13 +21,13 @@ var _ = Describe("Redis", Label("Redis"), func() {
 
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "small", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(serviceName, "deprecated-small", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
 
 		It("should provision a plan", func() {
-			instanceID, err := broker.Provision(serviceName, "small", map[string]any{})
+			instanceID, err := broker.Provision(serviceName, "deprecated-small", map[string]any{})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
@@ -49,7 +49,7 @@ var _ = Describe("Redis", Label("Redis"), func() {
 		})
 
 		It("should allow properties to be set on provision", func() {
-			_, err := broker.Provision(serviceName, "small", map[string]any{
+			_, err := broker.Provision(serviceName, "deprecated-small", map[string]any{
 				"instance_name":              "test-instance",
 				"resource_group":             "test-resource-group",
 				"subnet_id":                  "test-subnet-id",
@@ -76,14 +76,14 @@ var _ = Describe("Redis", Label("Redis"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small", nil)
+			instanceID, err = broker.Provision(serviceName, "deprecated-small", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, serviceName, "deprecated-small", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(
@@ -96,7 +96,7 @@ var _ = Describe("Redis", Label("Redis"), func() {
 		DescribeTable(
 			"allowed updates",
 			func(prop string, value any) {
-				Expect(broker.Update(instanceID, serviceName, "small", map[string]any{prop: value})).To(Succeed())
+				Expect(broker.Update(instanceID, serviceName, "deprecated-small", map[string]any{prop: value})).To(Succeed())
 			},
 			Entry("maxmemory_policy", "maxmemory_policy", "some_other_policy"),
 		)

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -142,7 +142,7 @@ output "password" {
   sensitive = true
 }
 output "tls_port" { value = azurerm_redis_cache.redis.ssl_port }
-output "status" { value = format("created cache %s (id: %s) URL: URL: https://portal.azure.com/#@%s/resource%s",
+output "status" { value = format("created cache %s (id: %s) URL: https://portal.azure.com/#@%s/resource%s",
   azurerm_redis_cache.redis.name,
   azurerm_redis_cache.redis.id,
   var.azure_tenant_id,


### PR DESCRIPTION
Customers should be moving to their own plan definitions and they should use v6 redis version

[#183863818](https://www.pivotaltracker.com/story/show/183863818)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

