### PR TITLE
test: increase pre-build timeout to match GCP

### DIFF
--- a/acceptance-tests/helpers/apps/prebuild.go
+++ b/acceptance-tests/helpers/apps/prebuild.go
@@ -21,7 +21,7 @@ func WithPreBuild(source string) Option {
 
 	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(session, time.Minute).Should(gexec.Exit(0))
+	Eventually(session, 5*time.Minute).Should(gexec.Exit(0))
 
 	err = os.WriteFile(path.Join(dir, "Procfile"), []byte(fmt.Sprintf("web: ./%s\n", name)), 0555)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
In the GCP brokerpak we increased the timeout for test app prebuild to 5 minutes, and it reduced test flakes. In order to fix similar flakes, we should increase the timeout in this brokerpak too.