### PR TITLE
test: add catalog tests to integration tests

### DIFF
--- a/integration-tests/cosmosdb_sql_test.go
+++ b/integration-tests/cosmosdb_sql_test.go
@@ -9,9 +9,16 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
-	const serviceName = "csb-azure-cosmosdb-sql"
+const (
+	cosmosDBSQLServiceName             = "csb-azure-cosmosdb-sql"
+	cosmosDBSQLServiceID               = "685e151f-3ad8-414f-ab5b-54abbb3dee02"
+	cosmosDBSQLServiceDisplayName      = "Azure CosmosDB Account - SQL API"
+	cosmosDBSQLServiceDescription      = "Azure CosmosDB Account - SQL API"
+	cosmosDBSQLServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/cosmos-db/"
+	cosmosDBSQLServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/cosmos-db/faq"
+)
 
+var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -24,17 +31,28 @@ var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
 		catalog, err := broker.Catalog()
 		Expect(err).NotTo(HaveOccurred())
 
-		service := testframework.FindService(catalog, serviceName)
-		Expect(service.ID).NotTo(BeNil())
-		Expect(service.Name).NotTo(BeNil())
+		service := testframework.FindService(catalog, cosmosDBSQLServiceName)
+		Expect(service.ID).To(Equal(cosmosDBSQLServiceID))
+		Expect(service.Description).To(Equal(cosmosDBSQLServiceDescription))
 		Expect(service.Tags).To(ConsistOf("azure", "cosmos", "cosmosdb", "cosmos-sql", "cosmosdb-sql", "preview"))
-		Expect(service.Metadata.ImageUrl).NotTo(BeNil())
-		Expect(service.Metadata.DisplayName).NotTo(BeNil())
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(cosmosDBSQLServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(cosmosDBSQLServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(cosmosDBSQLServiceSupportURL))
 		Expect(service.Plans).To(
 			ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("small")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("medium")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("large")}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small"),
+					ID:   Equal("ca38881c-2d6b-4db4-988c-d8e49f3293da"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("f666cd68-cbba-4c58-b532-bfc0cb533011"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("2d5ee55d-1315-40ca-a9e9-08f4f76e880f"),
+				}),
 			),
 		)
 	})
@@ -43,7 +61,7 @@ var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
 		planName := "large"
 		DescribeTable("property constraints",
 			func(params map[string]any, expectedErrorMsg string) {
-				_, err := broker.Provision(serviceName, planName, params)
+				_, err := broker.Provision(cosmosDBSQLServiceName, planName, params)
 
 				Expect(err).To(MatchError(ContainSubstring(expectedErrorMsg)))
 			},
@@ -65,7 +83,7 @@ var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
 		)
 
 		It("should provision a plan", func() {
-			instanceID, err := broker.Provision(serviceName, planName, nil)
+			instanceID, err := broker.Provision(cosmosDBSQLServiceName, planName, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
@@ -91,7 +109,7 @@ var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
 		})
 
 		It("should allow properties to be set on provision", func() {
-			_, err := broker.Provision(serviceName, planName, map[string]any{
+			_, err := broker.Provision(cosmosDBSQLServiceName, planName, map[string]any{
 				"instance_name":              "my-cosmosdb-sql",
 				"resource_group":             "my-resource-group",
 				"db_name":                    "my-db-name",
@@ -119,12 +137,12 @@ var _ = Describe("CosmosDB-SQL", Label("CosmosDB-SQL"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small", nil)
+			instanceID, err = broker.Provision(cosmosDBSQLServiceName, "small", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, cosmosDBSQLServiceName, "small", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/eventhubs_test.go
+++ b/integration-tests/eventhubs_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	eventHubsServiceName             = "csb-azure-eventhubs"
+	eventHubsServiceID               = "40b751ac-624d-11ea-8354-f38aff407636"
+	eventHubsServiceDisplayName      = "Event Hubs"
+	eventHubsServiceDescription      = "Simple, secure, and scalable real-time data ingestion"
+	eventHubsServiceDocumentationURL = "https://azure.microsoft.com/en-us/services/event-hubs/"
+	eventHubsServiceSupportURL       = "https://azure.microsoft.com/en-us/support/options/"
 )
 
 var _ = Describe("Event Hubs", Label("Event Hubs"), func() {
-	const serviceName = "csb-azure-eventhubs"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,35 @@ var _ = Describe("Event Hubs", Label("Event Hubs"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, eventHubsServiceName)
+		Expect(service.ID).To(Equal(eventHubsServiceID))
+		Expect(service.Description).To(Equal(eventHubsServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "eventhubs", "Event Hubs", "Azure", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(eventHubsServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(eventHubsServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(eventHubsServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("basic"),
+					ID:   Equal("3ac4fede-62ed-11ea-af59-cb26248cfe7b"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("standard"),
+					ID:   Equal("57e330ee-62ed-11ea-825c-23c5737ad688"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "basic", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(eventHubsServiceName, "basic", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +64,14 @@ var _ = Describe("Event Hubs", Label("Event Hubs"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "basic", nil)
+			instanceID, err = broker.Provision(eventHubsServiceName, "basic", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "basic", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, eventHubsServiceName, "basic", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/integration_test_suite_test.go
+++ b/integration-tests/integration_test_suite_test.go
@@ -19,6 +19,8 @@ const (
 	armClientSecret   = "arm-client-secret"
 	armSubscriptionID = "arm-subscription-id"
 	armTenantID       = "arm-tenant-id"
+	Name              = "Name"
+	ID                = "ID"
 )
 
 var (

--- a/integration-tests/mongodb_test.go
+++ b/integration-tests/mongodb_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	mongoDBServiceName             = "csb-azure-mongodb"
+	mongoDBServiceID               = "e5d2898e-534a-11ea-a4e8-00155da9789e"
+	mongoDBServiceDisplayName      = "Azure Cosmos DB's API for MongoDB"
+	mongoDBServiceDescription      = "The Cosmos DB service implements wire protocols for MongoDB.  Azure Cosmos DB is Microsoft's globally distributed, multi-model database service for mission-critical application"
+	mongoDBServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/cosmos-db/mongodb-introduction"
+	mongoDBServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/cosmos-db/faq"
 )
 
 var _ = Describe("MongoDB", Label("MongoDB"), func() {
-	const serviceName = "csb-azure-mongodb"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,39 @@ var _ = Describe("MongoDB", Label("MongoDB"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, mongoDBServiceName)
+		Expect(service.ID).To(Equal(mongoDBServiceID))
+		Expect(service.Description).To(Equal(mongoDBServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "mongodb", "preview", "cosmosdb-mongo", "cosmosdb-mongodb"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(mongoDBServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(mongoDBServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(mongoDBServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small"),
+					ID:   Equal("4ba45322-534c-11ea-b346-00155da9789e"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("6a28ad34-534c-11ea-9bac-00155da9789e"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("72227eac-534c-11ea-b7ca-00155da9789e"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "small", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(mongoDBServiceName, "small", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +68,14 @@ var _ = Describe("MongoDB", Label("MongoDB"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small", nil)
+			instanceID, err = broker.Provision(mongoDBServiceName, "small", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, mongoDBServiceName, "small", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/mssql_failover_test.go
+++ b/integration-tests/mssql_failover_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	mssqlFailoverGroupServiceName             = "csb-azure-mssql-failover-group"
+	mssqlFailoverGroupServiceID               = "76d0e602-2b79-4c1e-bbbe-03913a1cfda2"
+	mssqlFailoverGroupServiceDisplayName      = "Azure SQL Failover Group"
+	mssqlFailoverGroupServiceDescription      = "Manages auto failover group for managed Azure SQL on the Azure Platform"
+	mssqlFailoverGroupServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auto-failover-group/"
+	mssqlFailoverGroupServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auto-failover-group/"
 )
 
 var _ = Describe("MSSQL Auto-failover group", Label("MSSQL Auto-failover group"), func() {
-	const serviceName = "csb-azure-mssql-failover-group"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,39 @@ var _ = Describe("MSSQL Auto-failover group", Label("MSSQL Auto-failover group")
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, mssqlFailoverGroupServiceName)
+		Expect(service.ID).To(Equal(mssqlFailoverGroupServiceID))
+		Expect(service.Description).To(Equal(mssqlFailoverGroupServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "mssql", "sqlserver", "dr", "failover", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(mssqlFailoverGroupServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(mssqlFailoverGroupServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(mssqlFailoverGroupServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small-v2"),
+					ID:   Equal("eb9856fa-b285-11eb-ae46-536679aeffe8"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("c5e8ec57-ab5a-4bbf-ac6d-5075a97ed1a5"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("605a7a26-b1dd-4ce5-a382-4233e98469a8"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "small-v2", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(mssqlFailoverGroupServiceName, "small-v2", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +68,14 @@ var _ = Describe("MSSQL Auto-failover group", Label("MSSQL Auto-failover group")
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small-v2", nil)
+			instanceID, err = broker.Provision(mssqlFailoverGroupServiceName, "small-v2", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small-v2", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, mssqlFailoverGroupServiceName, "small-v2", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/mssql_server_test.go
+++ b/integration-tests/mssql_server_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	mssqlServerServiceName             = "csb-azure-mssql-server"
+	mssqlServerServiceID               = "a0ab0f36-f8e1-4045-8ddb-1918d2ceafe4"
+	mssqlServerServiceDisplayName      = "Azure SQL Server"
+	mssqlServerServiceDescription      = "Azure SQL Server (no database attached)"
+	mssqlServerServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/sql-database/"
+	mssqlServerServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/sql-database/"
 )
 
 var _ = Describe("MSSQL Server", Label("MSSQL Server"), func() {
-	const serviceName = "csb-azure-mssql-server"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,31 @@ var _ = Describe("MSSQL Server", Label("MSSQL Server"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, mssqlServerServiceName)
+		Expect(service.ID).To(Equal(mssqlServerServiceID))
+		Expect(service.Description).To(Equal(mssqlServerServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(mssqlServerServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(mssqlServerServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(mssqlServerServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("standard"),
+					ID:   Equal("1aab10e2-ca79-4755-855a-6073a739d2e0"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "standard", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(mssqlServerServiceName, "standard", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +60,14 @@ var _ = Describe("MSSQL Server", Label("MSSQL Server"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "standard", nil)
+			instanceID, err = broker.Provision(mssqlServerServiceName, "standard", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "standard", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, mssqlServerServiceName, "standard", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/mssql_test.go
+++ b/integration-tests/mssql_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	mssqlServiceName             = "csb-azure-mssql"
+	mssqlServiceID               = "2cfcad84-5824-11ea-b0e2-00155d4dfe6c"
+	mssqlServiceDisplayName      = "Azure SQL Database - Single Instance"
+	mssqlServiceDescription      = "Azure SQL Database is a fully managed service for the Azure Platform"
+	mssqlServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/sql-database/"
+	mssqlServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/sql-database/"
 )
 
 var _ = Describe("MSSQL", Label("MSSQL"), func() {
-	const serviceName = "csb-azure-mssql"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,43 @@ var _ = Describe("MSSQL", Label("MSSQL"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, mssqlServiceName)
+		Expect(service.ID).To(Equal(mssqlServiceID))
+		Expect(service.Description).To(Equal(mssqlServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "mssql", "sqlserver", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(mssqlServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(mssqlServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(mssqlServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small-v2"),
+					ID:   Equal("99ed044a-bf9b-11eb-a49a-e347783607d6"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("9295b05a-58c9-11ea-b9df-00155d2c938f"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("9dc5e814-58c9-11ea-9e77-00155d2c938f"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("extra-large"),
+					ID:   Equal("a94f7192-5cba-11ea-8b5a-00155d7cdd25"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "small-v2", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(mssqlServiceName, "small-v2", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +72,14 @@ var _ = Describe("MSSQL", Label("MSSQL"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small-v2", nil)
+			instanceID, err = broker.Provision(mssqlServiceName, "small-v2", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small-v2", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, mssqlServiceName, "small-v2", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	mysqlServiceName             = "csb-azure-mysql"
+	mysqlServiceID               = "cac4a46b-c4ec-49df-9b11-06457a29d31e"
+	mysqlServiceDisplayName      = "Azure Database for MySQL servers"
+	mysqlServiceDescription      = "Azure Database for MySQL servers"
+	mysqlServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/mysql/"
+	mysqlServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/mysql/"
 )
 
 var _ = Describe("MySQL", Label("MySQL"), func() {
-	const serviceName = "csb-azure-mysql"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,39 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, mysqlServiceName)
+		Expect(service.ID).To(Equal(mysqlServiceID))
+		Expect(service.Description).To(Equal(mysqlServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "mysql", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(mysqlServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(mysqlServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(mysqlServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small"),
+					ID:   Equal("828e324e-6b34-4f50-b224-9b956dd2d1b7"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("9eb836dd-4B90-4cF7-bc06-1986103802d3"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("6f8Ea44c-6840-4b0b-9068-f0cd9b17437c"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "small", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(mysqlServiceName, "small", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +68,14 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small", nil)
+			instanceID, err = broker.Provision(mysqlServiceName, "small", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, mysqlServiceName, "small", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/postgre_sql_test.go
+++ b/integration-tests/postgre_sql_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	postgreSQLServiceName             = "csb-azure-postgresql"
+	postgreSQLServiceID               = "ef89bc54-299a-4384-9dd6-4ea0cca11700"
+	postgreSQLServiceDisplayName      = "Azure Database for PostgreSQL"
+	postgreSQLServiceDescription      = "Azure Database for PostgreSQL"
+	postgreSQLServiceDocumentationURL = "https://azure.microsoft.com/en-us/services/postgresql/"
+	postgreSQLServiceSupportURL       = "https://azure.microsoft.com/en-us/services/postgresql/"
 )
 
 var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {
-	const serviceName = "csb-azure-postgresql"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,39 @@ var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, postgreSQLServiceName)
+		Expect(service.ID).To(Equal(postgreSQLServiceID))
+		Expect(service.Description).To(Equal(postgreSQLServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "postgresql", "postgres", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(postgreSQLServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(postgreSQLServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(postgreSQLServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small"),
+					ID:   Equal("aa1cf0f0-79fe-4132-a112-859fef9bf7cc"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("d83c74b9-0bb9-409e-bd26-8424ea908462"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("945b0ca1-5b5e-49b0-884a-20809103907e"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "small", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(postgreSQLServiceName, "small", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +68,14 @@ var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small", nil)
+			instanceID, err = broker.Provision(postgreSQLServiceName, "small", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, postgreSQLServiceName, "small", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(
@@ -60,7 +98,7 @@ var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			instanceID, err := broker.Provision(serviceName, "small", nil)
+			instanceID, err := broker.Provision(postgreSQLServiceName, "small", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = mockTerraform.SetTFState([]testframework.TFStateValue{
@@ -70,7 +108,7 @@ var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {
 				{Name: "jdbcUrl", Type: "string", Value: "bind.test.jdbcUrl"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			bindResult, err := broker.Bind(serviceName, "small", instanceID, nil)
+			bindResult, err := broker.Bind(postgreSQLServiceName, "small", instanceID, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(bindResult).To(Equal(map[string]any{

--- a/integration-tests/resource_group_test.go
+++ b/integration-tests/resource_group_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	resourceGroupServiceName             = "csb-azure-resource-group"
+	resourceGroupServiceID               = "57af72ea-b951-44cb-b814-1da900554ce8"
+	resourceGroupServiceDisplayName      = "Azure Resource Group"
+	resourceGroupServiceDescription      = "Azure Resource Group"
+	resourceGroupServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups"
+	resourceGroupServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups"
 )
 
 var _ = Describe("Resource Group", Label("Resource Group"), func() {
-	const serviceName = "csb-azure-resource-group"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,31 @@ var _ = Describe("Resource Group", Label("Resource Group"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, resourceGroupServiceName)
+		Expect(service.ID).To(Equal(resourceGroupServiceID))
+		Expect(service.Description).To(Equal(resourceGroupServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "preview"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(resourceGroupServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(resourceGroupServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(resourceGroupServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("standard"),
+					ID:   Equal("c995c72a-a5f4-48d8-9179-9e295cc535b7"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "standard", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(resourceGroupServiceName, "standard", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +60,14 @@ var _ = Describe("Resource Group", Label("Resource Group"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "standard", map[string]any{"instance_name": "resource-group-name"})
+			instanceID, err = broker.Provision(resourceGroupServiceName, "standard", map[string]any{"instance_name": "resource-group-name"})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "standard", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, resourceGroupServiceName, "standard", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/storage_account_test.go
+++ b/integration-tests/storage_account_test.go
@@ -4,11 +4,19 @@ import (
 	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	storageAccountServiceName             = "csb-azure-storage-account"
+	storageAccountServiceID               = "eb263d40-3a2e-4af1-9333-752acb1e6ea3"
+	storageAccountServiceDisplayName      = "Azure Storage Account"
+	storageAccountServiceDescription      = "Azure Storage Account"
+	storageAccountServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview"
+	storageAccountServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview"
 )
 
 var _ = Describe("Storage Account", Label("Storage Account"), func() {
-	const serviceName = "csb-azure-storage-account"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -17,9 +25,31 @@ var _ = Describe("Storage Account", Label("Storage Account"), func() {
 		Expect(mockTerraform.Reset()).To(Succeed())
 	})
 
+	It("should publish in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, storageAccountServiceName)
+		Expect(service.ID).To(Equal(storageAccountServiceID))
+		Expect(service.Description).To(Equal(storageAccountServiceDescription))
+		Expect(service.Tags).To(ConsistOf("azure", "storage", "Azure", "preview", "Storage"))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(storageAccountServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(storageAccountServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(storageAccountServiceSupportURL))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("standard"),
+					ID:   Equal("b9fe2b0c-1a95-4a1b-a576-60e7f9e42aad"),
+				}),
+			),
+		)
+	})
+
 	Describe("provisioning", func() {
 		It("should check location constraints", func() {
-			_, err := broker.Provision(serviceName, "standard", map[string]any{"location": "-Asia-northeast1"})
+			_, err := broker.Provision(storageAccountServiceName, "standard", map[string]any{"location": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("location: Does not match pattern '^[a-z][a-z0-9]+$'")))
 		})
@@ -30,14 +60,14 @@ var _ = Describe("Storage Account", Label("Storage Account"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "standard", nil)
+			instanceID, err = broker.Provision(storageAccountServiceName, "standard", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.Reset()).To(Succeed())
 		})
 
 		It("should prevent updating location due to is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "standard", map[string]any{"location": "asia-southeast1"})
+			err := broker.Update(instanceID, storageAccountServiceName, "standard", map[string]any{"location": "asia-southeast1"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(


### PR DESCRIPTION
This is to match the testing style in the GCP and AWS brokerpaks