### PR TITLE
chore: ensure that custom providers are statically linked

### DIFF
--- a/providers/terraform-provider-csbmssqldbrunfailover/Makefile
+++ b/providers/terraform-provider-csbmssqldbrunfailover/Makefile
@@ -7,7 +7,7 @@ DOCKER_OK := $(shell which docker 1>/dev/null 2>/dev/null; echo $$?)
 ifeq ($(GO_OK), 0)
   GO=go
 else ifeq ($(DOCKER_OK), 0)
-  GO=docker run --rm -v $(PWD)/../..:/src -w /src/providers/terraform-provider-csbmssqldbrunfailover -e GOARCH -e GOOS golang:$(GO-VERSION) go
+  GO=docker run --rm -v $(PWD)/../..:/src -w /src/providers/terraform-provider-csbmssqldbrunfailover -e GOARCH -e GOOS -e CGO_ENABLED golang:$(GO-VERSION) go
 else
   $(error either Go or Docker must be installed)
 endif
@@ -21,8 +21,8 @@ build: deps-go-binary cloudfoundry.org ## build the provider
 cloudfoundry.org: *.go */*.go
 	mkdir -p cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/linux_amd64
 	mkdir -p cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/darwin_amd64
-	GOOS=linux $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/linux_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
-	GOOS=darwin $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/darwin_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
+	CGO_ENABLED=0 GOOS=linux $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/linux_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
+	CGO_ENABLED=0 GOOS=darwin $(GO) build -o cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/darwin_amd64/terraform-provider-csbmssqldbrunfailover_v1.0.0
 
 .PHONY: clean
 clean: ## clean up build artifacts

--- a/providers/terraform-provider-csbsqlserver/Makefile
+++ b/providers/terraform-provider-csbsqlserver/Makefile
@@ -7,7 +7,7 @@ DOCKER_OK := $(shell which docker 1>/dev/null 2>/dev/null; echo $$?)
 ifeq ($(GO_OK), 0)
   GO=go
 else ifeq ($(DOCKER_OK), 0)
-  GO=docker run --rm -v $(PWD)/../..:/src -w /src/providers/terraform-provider-csbsqlserver -e GOARCH -e GOOS golang:$(GO-VERSION) go
+  GO=docker run --rm -v $(PWD)/../..:/src -w /src/providers/terraform-provider-csbsqlserver -e GOARCH -e GOOS -e CGO_ENABLED golang:$(GO-VERSION) go
 else
   $(error either Go or Docker must be installed)
 endif
@@ -21,8 +21,8 @@ build: deps-go-binary cloudfoundry.org ## build the provider
 cloudfoundry.org: *.go */*.go
 	mkdir -p cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/linux_amd64
 	mkdir -p cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/darwin_amd64
-	GOOS=linux $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/linux_amd64/terraform-provider-csbsqlserver_v1.0.0
-	GOOS=darwin $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/darwin_amd64/terraform-provider-csbsqlserver_v1.0.0
+	CGO_ENABLED=0 GOOS=linux $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/linux_amd64/terraform-provider-csbsqlserver_v1.0.0
+	CGO_ENABLED=0 GOOS=darwin $(GO) build -o cloudfoundry.org/cloud-service-broker/csbsqlserver/1.0.0/darwin_amd64/terraform-provider-csbsqlserver_v1.0.0
 
 .PHONY: clean
 clean: ## clean up build artifacts


### PR DESCRIPTION
The custom Terraform providers should be statically linked. It looks like a change in Go 1.20 resulted in them being dynamically linked when built on Linux, and then they didn't work in the CSB app because the binary buildpack doesn't have the required libraries available. This change ensures that they are statically linked.

[#184404359](https://www.pivotaltracker.com/story/show/184404359)