### PR TITLE
fix: Redis upgrade from brokerpak 1.4.0

### DIFF
--- a/azure-redis.yml
+++ b/azure-redis.yml
@@ -30,7 +30,6 @@ plans:
   properties:
     sku_name: Basic
     family: C
-    redis_version: "4"
     capacity: 1
     tls_min_version: "1.2"
     firewall_rules: []
@@ -41,7 +40,6 @@ plans:
   properties:
     sku_name: Basic
     family: C
-    redis_version: "4"
     capacity: 3
     tls_min_version: "1.2"
     firewall_rules: []
@@ -52,7 +50,6 @@ plans:
   properties:
     sku_name: Basic
     family: C
-    redis_version: "4"
     capacity: 5
     firewall_rules: []
     tls_min_version: "1.2"
@@ -63,7 +60,6 @@ plans:
   properties:
     sku_name: Standard
     family: C
-    redis_version: "4"
     capacity: 1
     firewall_rules: []
     tls_min_version: "1.2"
@@ -74,7 +70,6 @@ plans:
   properties:
     sku_name: Standard
     family: C
-    redis_version: "4"
     capacity: 3
     firewall_rules: []
     tls_min_version: "1.2"
@@ -85,7 +80,6 @@ plans:
   properties:
     sku_name: Standard
     family: C
-    redis_version: "4"
     capacity: 5
     firewall_rules: []
     tls_min_version: "1.2"
@@ -96,7 +90,6 @@ plans:
   properties:
     sku_name: Premium
     family: P
-    redis_version: "4"
     capacity: 1
     tls_min_version: "1.2"
     firewall_rules: []

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -90,7 +90,6 @@ var _ = Describe("Redis", Label("Redis"), func() {
 					HaveKeyWithValue("location", "westus"),
 					HaveKeyWithValue("sku_name", "Basic"),
 					HaveKeyWithValue("family", "C"),
-					HaveKeyWithValue("redis_version", "4"),
 					HaveKeyWithValue("capacity", BeNumerically("==", 1)),
 					HaveKeyWithValue("tls_min_version", "1.2"),
 					HaveKeyWithValue("firewall_rules", []any{}),


### PR DESCRIPTION
- Prior to 1.4.0 there was no "redis_version" property.
- In 1.4.0 the redis_version property was added, and existing plans were changed to specify redis_version=4. This was sensible at the time since previous versions created Redis v4 instance.
- Recently a test started to fail because new Redis instances created with brokerpak versions prior to 1.4.0 started to default to Redis v6 instances. This meant that when trying to upgrade to 1.4.0 or higher, an attempt was made to change the Redis version from v6 -> v4, resulting in the error:

  properties.redisVersion cannot be updated to 4.

- To resolve this, the value of redis_version for existing plans has been removed so that the Azure default will be used. This allows the upgrade to succeed for Redis v6.

[#184460134](https://www.pivotaltracker.com/story/show/184460134)