### PR TITLE
chore: add -local flag to goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ checkgoformat: ## checks that the Go code is formatted correctly
 	fi
 
 checkgoimports: ## checks that Go imports are formatted correctly
-	@@if [ -n "$$(${GO} run golang.org/x/tools/cmd/goimports -l -d .)" ]; then \
+	@@if [ -n "$$(${GO} run golang.org/x/tools/cmd/goimports -l -d -local csbbrokerpakazure .)" ]; then \
 		echo "goimports check failed: run 'make format'";                      \
 		exit 1;                                                                \
 	fi
@@ -234,7 +234,7 @@ staticcheck: ## runs staticcheck
 .PHONY: format
 format: ## format the source
 	${GOFMT} -s -e -l -w .
-	${GO} run golang.org/x/tools/cmd/goimports -l -w .
+	${GO} run golang.org/x/tools/cmd/goimports -l -w -local csbbrokerpakazure .
 	terraform fmt --recursive
 
 ./providers/terraform-provider-csbsqlserver/cloudfoundry.org/cloud-service-broker/csbsqlserver:

--- a/acceptance-tests/acceptance_suite_test.go
+++ b/acceptance-tests/acceptance_suite_test.go
@@ -1,8 +1,9 @@
 package acceptance_test
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/environment"
 	"testing"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/environment"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/helpers/apps/delete.go
+++ b/acceptance-tests/helpers/apps/delete.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"time"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"

--- a/acceptance-tests/helpers/apps/log.go
+++ b/acceptance-tests/helpers/apps/log.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"fmt"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/ginkgo/v2"
 )

--- a/acceptance-tests/helpers/apps/push.go
+++ b/acceptance-tests/helpers/apps/push.go
@@ -1,12 +1,13 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
-	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
+	"csbbrokerpakazure/acceptance-tests/helpers/random"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/helpers/apps/restage.go
+++ b/acceptance-tests/helpers/apps/restage.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"time"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"

--- a/acceptance-tests/helpers/apps/restart.go
+++ b/acceptance-tests/helpers/apps/restart.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"time"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"

--- a/acceptance-tests/helpers/apps/setenv.go
+++ b/acceptance-tests/helpers/apps/setenv.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"encoding/json"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 )

--- a/acceptance-tests/helpers/apps/start.go
+++ b/acceptance-tests/helpers/apps/start.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"time"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"

--- a/acceptance-tests/helpers/apps/url.go
+++ b/acceptance-tests/helpers/apps/url.go
@@ -1,9 +1,10 @@
 package apps
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"fmt"
 	"strings"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 

--- a/acceptance-tests/helpers/bindings/credential.go
+++ b/acceptance-tests/helpers/bindings/credential.go
@@ -1,9 +1,10 @@
 package bindings
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"fmt"
 	"strings"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	"code.cloudfoundry.org/jsonry"
 	. "github.com/onsi/ginkgo/v2"

--- a/acceptance-tests/helpers/brokers/create.go
+++ b/acceptance-tests/helpers/brokers/create.go
@@ -1,14 +1,15 @@
 package brokers
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/apps"
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
-	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/apps"
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
+	"csbbrokerpakazure/acceptance-tests/helpers/random"
 
 	"github.com/onsi/gomega"
 )

--- a/acceptance-tests/helpers/brokers/default.go
+++ b/acceptance-tests/helpers/brokers/default.go
@@ -1,9 +1,10 @@
 package brokers
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"fmt"
 	"os"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	"code.cloudfoundry.org/jsonry"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -1,9 +1,10 @@
 package brokers
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"fmt"
 	"os"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 
 	"github.com/onsi/ginkgo/v2"
 )

--- a/acceptance-tests/helpers/brokers/manifest.go
+++ b/acceptance-tests/helpers/brokers/manifest.go
@@ -1,9 +1,10 @@
 package brokers
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"os"
 	"path/filepath"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/acceptance-tests/helpers/lookupplan/lookup_plan.go
+++ b/acceptance-tests/helpers/lookupplan/lookup_plan.go
@@ -2,9 +2,10 @@
 package lookupplan
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"fmt"
 	"strings"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	"code.cloudfoundry.org/jsonry"
 	. "github.com/onsi/ginkgo/v2"

--- a/acceptance-tests/helpers/servicekeys/create.go
+++ b/acceptance-tests/helpers/servicekeys/create.go
@@ -1,9 +1,10 @@
 package servicekeys
 
 import (
+	"time"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
-	"time"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"

--- a/acceptance-tests/helpers/servicekeys/get.go
+++ b/acceptance-tests/helpers/servicekeys/get.go
@@ -1,10 +1,11 @@
 package servicekeys
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"encoding/json"
 	"reflect"
 	"strings"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 
 	. "github.com/onsi/gomega"
 )

--- a/acceptance-tests/helpers/services/guid.go
+++ b/acceptance-tests/helpers/services/guid.go
@@ -1,8 +1,9 @@
 package services
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"strings"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 )
 
 func (s *ServiceInstance) GUID() string {

--- a/acceptance-tests/helpers/services/upgrade.go
+++ b/acceptance-tests/helpers/services/upgrade.go
@@ -1,14 +1,14 @@
 package services
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 	"encoding/json"
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
-
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
 )
 
 func (s *ServiceInstance) Upgrade() {

--- a/acceptance-tests/mongodb_test.go
+++ b/acceptance-tests/mongodb_test.go
@@ -1,11 +1,12 @@
 package acceptance_test
 
 import (
+	"fmt"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/matchers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/mssql_failover_group_test.go
+++ b/acceptance-tests/mssql_failover_group_test.go
@@ -1,12 +1,13 @@
 package acceptance_test
 
 import (
+	"fmt"
+	"regexp"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/matchers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"fmt"
-	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/mssql_fog_db_subsume_test.go
+++ b/acceptance-tests/mssql_fog_db_subsume_test.go
@@ -1,14 +1,15 @@
 package acceptance_test
 
 import (
+	"os/exec"
+	"strings"
+	"time"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/matchers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"os/exec"
-	"strings"
-	"time"
 
 	"github.com/onsi/gomega/gexec"
 

--- a/acceptance-tests/upgrade/update_and_upgrade_cosmos_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_cosmos_test.go
@@ -1,11 +1,12 @@
 package upgrade_test
 
 import (
+	"fmt"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
@@ -1,13 +1,14 @@
 package upgrade_test
 
 import (
+	"fmt"
+	"os/exec"
+	"time"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"fmt"
-	"os/exec"
-	"time"
 
 	"github.com/onsi/gomega/gexec"
 

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_failover_group_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_failover_group_test.go
@@ -1,12 +1,13 @@
 package upgrade_test
 
 import (
+	"fmt"
+	"regexp"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"fmt"
-	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_test.go
@@ -1,11 +1,12 @@
 package upgrade_test
 
 import (
+	"fmt"
+
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/random"
 	"csbbrokerpakazure/acceptance-tests/helpers/services"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/acceptance-tests/upgrade/upgrade_suite_test.go
+++ b/acceptance-tests/upgrade/upgrade_suite_test.go
@@ -1,9 +1,10 @@
 package upgrade_test
 
 import (
-	"csbbrokerpakazure/acceptance-tests/helpers/environment"
 	"flag"
 	"testing"
+
+	"csbbrokerpakazure/acceptance-tests/helpers/environment"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/go.mod
+++ b/go.mod
@@ -21,15 +21,9 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
-)
-
-require (
 	cloud.google.com/go v0.105.0 // indirect
 	cloud.google.com/go/compute v1.14.0 // indirect
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect
 	cloud.google.com/go/storage v1.27.0 // indirect
 	code.cloudfoundry.org/credhub-cli v0.0.0-20220620130410-645eee56ecdb // indirect
@@ -47,8 +41,10 @@ require (
 	github.com/cloudfoundry/socks5-proxy v0.2.60 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -56,6 +52,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/providers/terraform-provider-csbsqlserver/connector/connector_suite_test.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector_suite_test.go
@@ -1,11 +1,12 @@
 package connector_test
 
 import (
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/connector"
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/testhelpers"
 	"database/sql"
 	"testing"
 	"time"
+
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/connector"
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/testhelpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/providers/terraform-provider-csbsqlserver/connector/connector_test.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector_test.go
@@ -2,8 +2,9 @@ package connector_test
 
 import (
 	"context"
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/testhelpers"
 	"fmt"
+
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/testhelpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/providers/terraform-provider-csbsqlserver/csbsqlserver/binding_resource.go
+++ b/providers/terraform-provider-csbsqlserver/csbsqlserver/binding_resource.go
@@ -2,8 +2,9 @@ package csbsqlserver
 
 import (
 	"context"
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/connector"
 	"fmt"
+
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/connector"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/providers/terraform-provider-csbsqlserver/csbsqlserver/binding_resource_test.go
+++ b/providers/terraform-provider-csbsqlserver/csbsqlserver/binding_resource_test.go
@@ -1,11 +1,12 @@
 package csbsqlserver_test
 
 import (
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/csbsqlserver"
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/testhelpers"
 	"database/sql"
 	"fmt"
 	"time"
+
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/csbsqlserver"
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/testhelpers"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/providers/terraform-provider-csbsqlserver/csbsqlserver/provider.go
+++ b/providers/terraform-provider-csbsqlserver/csbsqlserver/provider.go
@@ -3,6 +3,7 @@ package csbsqlserver
 
 import (
 	"context"
+
 	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/connector"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/providers/terraform-provider-csbsqlserver/csbsqlserver/provider_test.go
+++ b/providers/terraform-provider-csbsqlserver/csbsqlserver/provider_test.go
@@ -1,10 +1,11 @@
 package csbsqlserver_test
 
 import (
-	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/csbsqlserver"
 	"encoding/json"
 	"fmt"
 	"regexp"
+
+	"csbbrokerpakazure/providers/terraform-provider-csbsqlserver/csbsqlserver"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"


### PR DESCRIPTION
This separates imports into stdlib, local and external, making it clearer what comes from where
