### PR TITLE
chore: revert "chore: update terraform-provider-azurerm to v3"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -43,8 +43,8 @@ terraform_binaries:
   version: 2.33.0
   source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.33.0.zip
 - name: terraform-provider-azurerm
-  version: 3.46.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.46.0.zip
+  version: 2.99.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.99.0.zip
 - name: terraform-provider-random
   version: 3.4.3
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.4.3.zip

--- a/terraform/azure-cosmosdb/provision-cosmosdb-sql.tf
+++ b/terraform/azure-cosmosdb/provision-cosmosdb-sql.tf
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
   }
 }

--- a/terraform/azure-eventhubs/azure-eventhubs-bind.tf
+++ b/terraform/azure-eventhubs/azure-eventhubs-bind.tf
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
   }
 }

--- a/terraform/azure-eventhubs/azure-eventhubs.tf
+++ b/terraform/azure-eventhubs/azure-eventhubs.tf
@@ -30,7 +30,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
   }
 }

--- a/terraform/azure-mongodb/azure-mongodb.tf
+++ b/terraform/azure-mongodb/azure-mongodb.tf
@@ -42,7 +42,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
   }
 }

--- a/terraform/azure-mssql-db-failover/azure-versions.tf
+++ b/terraform/azure-mssql-db-failover/azure-versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.59.0"
     }
   }
 }

--- a/terraform/azure-mssql-db/provision/mssql-db-versions.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.59.0"
     }
   }
 }

--- a/terraform/azure-mssql-failover/provision-mssql-failover.tf
+++ b/terraform/azure-mssql-failover/provision-mssql-failover.tf
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.53.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-mssql-server/mssql-server-provision.tf
+++ b/terraform/azure-mssql-server/mssql-server-provision.tf
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-mssql/provision-mssql.tf
+++ b/terraform/azure-mssql/provision-mssql.tf
@@ -31,7 +31,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -42,7 +42,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-postgres/postgres-provision.tf
+++ b/terraform/azure-postgres/postgres-provision.tf
@@ -33,7 +33,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-resource-group/resource-group-provision.tf
+++ b/terraform/azure-resource-group/resource-group-provision.tf
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
   }
 }

--- a/terraform/azure-storage/account-provision.tf
+++ b/terraform/azure-storage/account-provision.tf
@@ -30,7 +30,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.45.0"
+      version = ">=2.33.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -90,7 +90,9 @@ resource "azurerm_storage_account" "account" {
 resource "azurerm_storage_account_network_rules" "account_network_rule" {
   count = length(var.authorized_networks) != 0 ? 1 : 0
 
-  storage_account_id         = azurerm_storage_account.account.id
+  resource_group_name  = local.resource_group
+  storage_account_name = azurerm_storage_account.account.name
+
   default_action             = "Deny"
   virtual_network_subnet_ids = var.authorized_networks[*]
 }


### PR DESCRIPTION
This reverts commit b5cbc032f9c44cf9fe9360d9f9257ee2dcda548f.

The commit was causing test failures because the property `extended_auditing_policy` has been removed.

[#183376379](https://www.pivotaltracker.com/story/show/183376379)
