### PR TITLE
chore: [MSSQL] remove xlarge example

### DIFF
--- a/azure-mssql.yml
+++ b/azure-mssql.yml
@@ -226,9 +226,3 @@ examples:
   provision_params: {}
   bind_params: {}
   bind_can_fail: true
-- name: azuresql-db-xlarge-configuration
-  description: Create an extra large Azure SQL Database
-  plan_id: a94f7192-5cba-11ea-8b5a-00155d7cdd25
-  provision_params: {}
-  bind_params: {}
-  bind_can_fail: true  


### PR DESCRIPTION
This example is just a variation of the larger or medium one with a different size and no additional functionality. There is no need to test every possible combination.

Also, this example is one of the most costly ones by removing it we might reduce testing costs slightly.

### Checklist:

* ~[ ] Have you added Release Notes in the docs repositories?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

