### PR TITLE
fix: [MSSQL] default fog server_pairs not read from config

### DIFF
--- a/azure-mssql-fog-run-failover.yml
+++ b/azure-mssql-fog-run-failover.yml
@@ -41,6 +41,7 @@ provision:
     type: object
     details: 'JSON hash of server pair name to set of server names. { "name": { "primary":{"server_name":"...", "resource_group":..."}, "secondary":{"server_name":"...", "resource_group":..."}, ...}'
     required: true
+    default: ${config("service.csb-azure-mssql-fog-run-failover.provision.defaults.server_pairs")}
   - field_name: azure_tenant_id
     type: string
     details: Azure Tenant to create resource in


### PR DESCRIPTION
Although we were exposing a config to allow passing server_pairs
to csb-azure-mssql-fog-run-failover service, it was never used.

CSB complained whenever we tried to create an instance without
specifying server_pairs explicitly.

The name of the property in the config file is very intriguing:
service.csb-azure-mssql-fog-run-failover.provision.defaults.server_pairs
because it seems to suggest that CSB would read some "magic" paths
to determine default values, etc.
But I don't know if this feature was removed or has never worked.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

