### PR TITLE
fix: [MSSQL] object reassignment when binding is deleted

### DIFF
--- a/acceptance-tests/mssql_failover_group_test.go
+++ b/acceptance-tests/mssql_failover_group_test.go
@@ -36,7 +36,7 @@ var _ = Describe("MSSQL Failover Group", Label("mssql"), func() {
 
 		By("creating a schema using the first app")
 		schema := random.Name(random.WithMaxLength(10))
-		appOne.PUT("", schema)
+		appOne.PUT("", "%s?dbo=false", schema)
 
 		By("setting a key-value using the first app")
 		keyOne := random.Hexadecimal()
@@ -63,11 +63,15 @@ var _ = Describe("MSSQL Failover Group", Label("mssql"), func() {
 		Expect(appTwo.GET("%s/%s", schema, keyOne)).To(Equal(valueOne))
 		Expect(appTwo.GET("%s/%s", schema, keyTwo)).To(Equal(valueTwo))
 
+		By("deleting binding one the binding two keeps reading the value - object reassignment works")
+		bindingOne.Unbind()
+		Expect(appTwo.GET("%s/%s", schema, keyOne)).To(Equal(valueOne))
+
 		By("reverting the failover")
 		failoverServiceInstance.Delete()
 
-		By("dropping the schema")
-		appOne.DELETE(schema)
+		By("dropping the schema using the second app")
+		appTwo.DELETE(schema)
 	})
 })
 

--- a/acceptance-tests/mssql_fog_existing_test.go
+++ b/acceptance-tests/mssql_fog_existing_test.go
@@ -74,7 +74,7 @@ var _ = Describe("MSSQL Failover Group Existing", Label("mssql-failover-group"),
 
 		By("creating a schema")
 		schema := random.Name(random.WithMaxLength(10))
-		app.PUT("", schema)
+		app.PUT("", "%s?dbo=false", schema)
 
 		By("setting a key-value")
 		key := random.Hexadecimal()

--- a/acceptance-tests/mssql_server_and_db_test.go
+++ b/acceptance-tests/mssql_server_and_db_test.go
@@ -60,7 +60,7 @@ var _ = Describe("MSSQL Server and DB", Label("mssql-server"), func() {
 
 		By("creating a schema using the first app")
 		schema := random.Name(random.WithMaxLength(10))
-		appOne.PUT("", schema)
+		appOne.PUT("", "%s?dbo=false", schema)
 
 		By("setting a key-value using the first app")
 		key := random.Hexadecimal()
@@ -71,8 +71,13 @@ var _ = Describe("MSSQL Server and DB", Label("mssql-server"), func() {
 		got := appTwo.GET("%s/%s", schema, key)
 		Expect(got).To(Equal(value))
 
-		By("dropping the schema using the first app")
-		appOne.DELETE(schema)
+		By("deleting binding one the binding two keeps reading the value - object reassignment works")
+		binding.Unbind()
+		got = appTwo.GET("%s/%s", schema, key)
+		Expect(got).To(Equal(value))
+
+		By("dropping the schema using the second app")
+		appTwo.DELETE(schema)
 	})
 })
 

--- a/acceptance-tests/mssql_test.go
+++ b/acceptance-tests/mssql_test.go
@@ -33,7 +33,7 @@ var _ = Describe("MSSQL", Label("mssql"), func() {
 
 		By("creating a schema using the first app")
 		schema := random.Name(random.WithMaxLength(10))
-		appOne.PUT("", schema)
+		appOne.PUT("", "%s?dbo=false", schema)
 
 		By("setting a key-value using the first app")
 		key := random.Hexadecimal()
@@ -44,7 +44,12 @@ var _ = Describe("MSSQL", Label("mssql"), func() {
 		got := appTwo.GET("%s/%s", schema, key)
 		Expect(got).To(Equal(value))
 
-		By("dropping the schema using the first app")
-		appOne.DELETE(schema)
+		By("deleting binding one the binding two keeps reading the value - object reassignment works")
+		binding.Unbind()
+		got = appTwo.GET("%s/%s", schema, key)
+		Expect(got).To(Equal(value))
+
+		By("dropping the schema using the second app")
+		appTwo.DELETE(schema)
 	})
 })


### PR DESCRIPTION
[#185100152](https://www.pivotaltracker.com/story/show/185100152)

Related PRs:
- https://github.com/cloudfoundry/csb-brokerpak-azure/pull/591

I was expecting these tests to fail but they aren't. We should understand why tests are not failing, and implement some which fail, otherwise we can't be sure whether we have fixed the issue or not.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

