### PR TITLE
test: older versions don't have '.envrc' file

### DIFF
--- a/acceptance-tests/upgrade/upgrade_suite_test.go
+++ b/acceptance-tests/upgrade/upgrade_suite_test.go
@@ -43,8 +43,8 @@ var _ = BeforeSuite(func() {
 		releasedBuildDir = brokerpaks.DownloadBrokerpak(fromVersion, brokerpaks.TargetDir(fromVersion))
 	}
 
-	preflight(developmentBuildDir) // faster feedback as no download
-	preflight(releasedBuildDir)
+	preflight(developmentBuildDir)
+	// Don't do a preflight on releasedBuildDir as older versions (tile v1.3.0 and earlier) don't have a .envrc file
 })
 
 // preflight checks that a specified broker dir is viable so that the user gets fast feedback


### PR DESCRIPTION
Upgrade test from v1.3.0 and earlier started to fail because of a "preflight" check recently adding which ensures that the input looks right before pusing a broker/brokerpak app.
