### PR TITLE
chore: bump Azure Terraform provider to V3

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_test.go
@@ -114,6 +114,7 @@ var _ = Describe("UpgradeMssqlDBTest", Label("mssql-db"), func() {
 			appOne.DELETE(schema)
 		})
 	})
+
 	When("using a config file for broker configuration", func() {
 		It("it should respect the config as if it were set via an env var", func() {
 			By("pushing a broker with a config file")
@@ -184,6 +185,7 @@ var _ = Describe("UpgradeMssqlDBTest", Label("mssql-db"), func() {
 		})
 
 	})
+
 	When("upgrading broker version", Label("ancient"), func() {
 		It("should continue to work", func() {
 			By("pushing an ancient broker version")

--- a/azure-mssql-db-failover-group.yml
+++ b/azure-mssql-db-failover-group.yml
@@ -76,16 +76,12 @@ provision:
       maxLength: 63
       minLength: 6
       pattern: ^[a-z][a-z0-9-]+$
-    tf_attribute: azurerm_sql_failover_group.failover_group.name
-    tf_attribute_skip: existing
   - field_name: db_name
     type: string
     details: Name for your database
     default: csb-fog-db-${request.instance_id}
     constraints:
       maxLength: 64
-    tf_attribute: azurerm_mssql_database.primary_db.name
-    tf_attribute_skip: existing
   - field_name: server_pair
     type: string
     details: Name of server pair from server_credential_pairs to create database upon

--- a/azure-mssql-db.yml
+++ b/azure-mssql-db.yml
@@ -71,7 +71,6 @@ provision:
     default: csb-db-${request.instance_id}
     constraints:
       maxLength: 64
-    tf_attribute: azurerm_mssql_database.azure_sql_db.name
   - field_name: server
     type: string
     details: Name of server from server_credentials to create database upon

--- a/manifest.yml
+++ b/manifest.yml
@@ -35,14 +35,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
   default: true  
 - name: terraform-provider-azurerm
-  version: 2.20.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.20.0.zip
-- name: terraform-provider-azurerm
-  version: 2.33.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.33.0.zip
-- name: terraform-provider-azurerm
-  version: 2.99.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.99.0.zip
+  version: 3.81.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.81.0.zip
 - name: terraform-provider-random
   version: 3.5.1
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.5.1.zip

--- a/terraform/azure-cosmosdb/provision/versions.tf
+++ b/terraform/azure-cosmosdb/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-eventhubs/bind/versions.tf
+++ b/terraform/azure-eventhubs/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-eventhubs/provision/versions.tf
+++ b/terraform/azure-eventhubs/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-mongodb/provision/versions.tf
+++ b/terraform/azure-mongodb/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-mssql-db-failover/azure-versions.tf
+++ b/terraform/azure-mssql-db-failover/azure-versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.59.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-mssql-db/provision/mssql-db-versions.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.59.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-mssql-failover/provision/versions.tf
+++ b/terraform/azure-mssql-failover/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.53.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-mssql-server/provision/versions.tf
+++ b/terraform/azure-mssql-server/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-mssql/provision/versions.tf
+++ b/terraform/azure-mssql/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-mysql/provision/versions.tf
+++ b/terraform/azure-mysql/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-postgres/provision/versions.tf
+++ b/terraform/azure-postgres/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-redis/provision/versions.tf
+++ b/terraform/azure-redis/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/azure-resource-group/provision/versions.tf
+++ b/terraform/azure-resource-group/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
   }
 }

--- a/terraform/azure-storage/provision/main.tf
+++ b/terraform/azure-storage/provision/main.tf
@@ -48,8 +48,7 @@ resource "azurerm_storage_account" "account" {
 resource "azurerm_storage_account_network_rules" "account_network_rule" {
   count = length(var.authorized_networks) != 0 ? 1 : 0
 
-  resource_group_name  = local.resource_group
-  storage_account_name = azurerm_storage_account.account.name
+  storage_account_id = azurerm_storage_account.account.id
 
   default_action             = "Deny"
   virtual_network_subnet_ids = var.authorized_networks[*]

--- a/terraform/azure-storage/provision/versions.tf
+++ b/terraform/azure-storage/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.33.0"
+      version = ">=3.81.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Now that we no longer support subsume, it's possible to update the Azure Terraform provider to V3. Previously this was problematic as running an update/upgrade on service instances that supported subsume would try to run `terraform output` which failed as the schema used by the Azure provider V2/V3 has changed. With subsume no longer supported, we don't need to run `terraform output` (trigged by `tf_attribute`) and we don't see the error any more.

[#183376379](https://www.pivotaltracker.com/story/show/183376379)