### PR TITLE
feat: restrict upgrade to v1.6 only

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,13 +24,6 @@ platforms:
 #   arch: amd64
 terraform_binaries:
 - name: terraform
-  version: 1.1.9
-  source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
-  default: false
-- name: terraform
-  version: 1.4.6
-  source: https://github.com/hashicorp/terraform/archive/v1.4.6.zip
-- name: terraform
   version: 1.5.7
   source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
   default: true  
@@ -60,15 +53,7 @@ terraform_binaries:
   source: https://github.com/cyrilgdn/terraform-provider-postgresql/archive/v1.21.0.zip
   provider: cyrilgdn/postgresql
   url_template: https://github.com/cyrilgdn/${name}/releases/download/v${version}/terraform-provider-postgresql_${version}_${os}_${arch}.zip
-terraform_state_provider_replacements:
-  registry.terraform.io/-/azurerm: "registry.terraform.io/hashicorp/azurerm"
-  registry.terraform.io/-/random: "registry.terraform.io/hashicorp/random"
-  registry.terraform.io/-/mysql: "registry.terraform.io/hashicorp/mysql"
-  registry.terraform.io/-/null: "registry.terraform.io/hashicorp/null"
-  registry.terraform.io/-/postgresql: "registry.terraform.io/cyrilgdn/postgresql"
 terraform_upgrade_path:
-- version: 1.1.9
-- version: 1.4.6
 - version: 1.5.7
 env_config_mapping:
   ARM_SUBSCRIPTION_ID: azure.subscription_id


### PR DESCRIPTION
In order to reduce the size of the brokerpak, obsolete Terraform providers have been removed. As a result, to get to this version through upgrading, you must upgrade to v1.6 first and upgrade all service instances to v1.6. This can be done via "cf upgrade-service", or for bulk upgrades consider the plugin: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin You can then upgrade to this version, and again upgrade all the service instances.

[#186588913](https://www.pivotaltracker.com/story/show/186588913)

