### PR TITLE
chore: remove unused "null" provider

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -36,9 +36,6 @@ terraform_binaries:
 - name: terraform-provider-mysql
   version: 1.9.0
   source: https://github.com/terraform-providers/terraform-provider-mysql/archive/v1.9.0.zip
-- name: terraform-provider-null
-  version: 3.2.2
-  source: https://github.com/terraform-providers/terraform-provider-null/archive/v3.2.2.zip
 - name: terraform-provider-csbsqlserver
   version: 1.0.5
   source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.5.zip


### PR DESCRIPTION
I can't find any usages of the "null_resource" so we do not need this provider.

[#186588913](https://www.pivotaltracker.com/story/show/186588913)