### PR TITLE
fix: mongodb the field 'unique' is not valid for _id

### DIFF
--- a/azure-mongodb.yml
+++ b/azure-mongodb.yml
@@ -239,6 +239,8 @@ examples:
     db_name: 'musicdb',
     collection_name: 'album',
     shard_key: '_id',
-    location: 'westus2'
+    location: 'westus2',
+    unique_indexes: '',
+    indexes: '_id'
   }
   bind_params: {}

--- a/azure-mongodb.yml
+++ b/azure-mongodb.yml
@@ -111,6 +111,15 @@ provision:
     type: string
     details: Name for your shard key
     default: uniqueKey
+  - field_name: indexes
+    required: false
+    type: string
+    details: A comma-separated list of non-unique indexes.
+    default: ""
+  - field_name: unique_indexes
+    required: false
+    type: string
+    details: A comma-separated list of unique indexes.
   - field_name: location
     type: string
     details: The location of the MongoDB instance.
@@ -190,6 +199,10 @@ provision:
     default: ${json.marshal(request.default_labels)}
     overwrite: true
     type: object
+  - name: unique_indexes
+    default: "_id,${shard_key}"
+    overwrite: false
+    type: string
   template_refs:
     main: terraform/azure-mongodb/provision/main.tf
     data: terraform/azure-mongodb/provision/data.tf

--- a/integration-tests/mongodb_test.go
+++ b/integration-tests/mongodb_test.go
@@ -63,6 +63,45 @@ var _ = Describe("MongoDB", Label("MongoDB"), func() {
 		})
 	})
 
+	Describe("provisioning with custom shard_key", func() {
+		It("should affect the value of unique_indexes computed value", func() {
+			_, err := broker.Provision(mongoDBServiceName, "small", map[string]any{"shard_key": "shard"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
+				SatisfyAll(
+					HaveKeyWithValue("shard_key", "shard"),
+					HaveKeyWithValue("unique_indexes", "_id,shard"),
+				),
+			)
+		})
+	})
+
+	Describe("provisioning with custom unique_indexes", func() {
+		It("should override computed unique_indexes", func() {
+			_, err := broker.Provision(mongoDBServiceName, "small", map[string]any{"unique_indexes": "uidx1,uidx2", "shard_key": "shard"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
+				SatisfyAll(
+					HaveKeyWithValue("unique_indexes", "uidx1,uidx2"),
+				),
+			)
+		})
+	})
+
+	Describe("provisioning with default values", func() {
+		It("should use default values for shard_key, indexes and unique_indexes", func() {
+			_, err := broker.Provision(mongoDBServiceName, "small", map[string]any{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
+				SatisfyAll(
+					HaveKeyWithValue("indexes", ""),
+					HaveKeyWithValue("shard_key", "uniqueKey"),
+					HaveKeyWithValue("unique_indexes", "_id,uniqueKey"),
+				),
+			)
+		})
+	})
+
 	Describe("updating instance", func() {
 		var instanceID string
 

--- a/terraform-tests/cosmosdb_mongo_test.go
+++ b/terraform-tests/cosmosdb_mongo_test.go
@@ -51,6 +51,8 @@ var _ = Describe("CosmosDB Mongo", Label("cosmosdb-mongo-terraform"), Ordered, f
 		"private_endpoint_subnet_id":      "",
 		"public_network_access_enabled":   true,
 		"labels":                          map[string]any{"k1": "v1"},
+		"indexes":                         "",
+		"unique_indexes":                  "_id,key1",
 	}
 
 	BeforeAll(func() {
@@ -132,7 +134,19 @@ var _ = Describe("CosmosDB Mongo", Label("cosmosdb-mongo-terraform"), Ordered, f
 					"database_name":       Equal(dbName),
 					"default_ttl_seconds": BeNumerically("==", 777),
 					"shard_key":           Equal("key1"),
-				}))
+
+					"index": BeEquivalentTo([]any{
+						map[string]any{
+							"keys":   []any{"_id"},
+							"unique": true,
+						},
+						map[string]any{
+							"keys":   []any{"key1"},
+							"unique": true,
+						},
+					}),
+				}),
+			)
 		})
 	})
 

--- a/terraform/azure-mongodb/provision/main.tf
+++ b/terraform/azure-mongodb/provision/main.tf
@@ -98,14 +98,20 @@ resource "azurerm_cosmosdb_mongo_collection" "mongo-collection" {
   default_ttl_seconds = "777"
   shard_key           = var.shard_key
 
-  index {
-    keys   = [var.shard_key]
-    unique = true
+  dynamic "index" {
+    for_each = compact(split(",", coalesce(var.indexes, ",")))
+    content {
+      keys   = [index.value]
+      unique = false
+    }
   }
 
-  index {
-    keys   = ["_id"]
-    unique = true
+  dynamic "index" {
+    for_each = compact(split(",", coalesce(var.unique_indexes, ",")))
+    content {
+      keys   = [index.value]
+      unique = true
+    }
   }
 
   lifecycle {

--- a/terraform/azure-mongodb/provision/variables.tf
+++ b/terraform/azure-mongodb/provision/variables.tf
@@ -23,3 +23,5 @@ variable "authorized_network" { type = string }
 variable "private_endpoint_subnet_id" { type = string }
 variable "private_dns_zone_ids" { type = list(string) }
 variable "public_network_access_enabled" { type = bool }
+variable "unique_indexes" { type = string }
+variable "indexes" { type = string }


### PR DESCRIPTION
[#186981808](https://www.pivotaltracker.com/story/show/186981808)

We started to see some errors related to 'unique' field being invalid for _id key. There is very little clarity online about the issue. More so, if we focus on Azure CosmoDB for MongoDB.

After some trial and error, it seems that mongodb instances created in location 'westus2' have started imposing this, while instances created in location 'westus' work without issues with the same configuration.

Changes in this commit is an attempt to cover our backs and be prepared in case Azure imposes this validation on all locations in the near future.

These changes should be backward compatible without any user intervention. Both, from the point of view of existing plans, and from the point of view of existing instances.
HOWEVER, we may want to introduce an upgrade test to ensure edge cases with default values work as expected.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

