### PR TITLE
fix: example-test-spring-music-mongo-db-started-failing

### DIFF
--- a/azure-mongodb.yml
+++ b/azure-mongodb.yml
@@ -229,7 +229,9 @@ examples:
   provision_params: {
     db_name: 'musicdb',
     collection_name: 'album',
-    shard_key: '_id'
+    shard_key: '_id',
+    unique_indexes: '',
+    indexes: '_id'
   }
   bind_params: {}
 - name: spring-music-mongo-db-alternate-rg


### PR DESCRIPTION
[#186981808](https://www.pivotaltracker.com/story/show/186981808)

Related to PR:
- https://github.com/cloudfoundry/csb-brokerpak-azure/pull/676

Previously, example-test named `spring-music-mongo-db` was working without issues. It seems `westus` location is starting to throw the same kind of issues now too.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

