### PR TITLE
chore: remove run-in-docker logic from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), $(IAAS)-broker)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), $(IAAS)-broker-pw)
 GSB_PROVISION_DEFAULTS := $(or $(GSB_PROVISION_DEFAULTS), {"resource_group": "broker-cf-test"})
 
-GO=go
-GOFMT=gofmt
 BROKER_GO_OPTS=PORT=8080 \
 				DB_TYPE=sqlite3 \
 				DB_PATH=/tmp/csb-db \
@@ -42,8 +40,8 @@ GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) 
 .PHONY: deps-go-binary
 deps-go-binary:
 ifeq ($(SKIP_GO_VERSION_CHECK),)
-	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
 		exit 1; \
 	fi
 endif
@@ -161,13 +159,13 @@ $(PAK_BUILD_CACHE_PATH):
 
 .PHONY: latest-csb
 latest-csb: ## point to the very latest CSB on GitHub
-	$(GO) get -d github.com/cloudfoundry/cloud-service-broker@main
-	$(GO) mod tidy
+	go get -d github.com/cloudfoundry/cloud-service-broker@main
+	go mod tidy
 
 .PHONY: local-csb
 local-csb: ## point to a local CSB repo
 	echo "replace \"github.com/cloudfoundry/cloud-service-broker\" => \"$$PWD/../cloud-service-broker\"" >>go.mod
-	$(GO) mod tidy
+	go mod tidy
 
 ###### lint ###################################################################
 
@@ -181,27 +179,27 @@ checktfformat: ## checks that Terraform HCL is formatted correctly
 	fi
 
 checkgoformat: ## checks that the Go code is formatted correctly
-	@@if [ -n "$$(${GOFMT} -s -e -l -d .)" ]; then       \
+	@@if [ -n "$$(gofmt -s -e -l -d .)" ]; then       \
 		echo "gofmt check failed: run 'make format'"; \
 		exit 1;                                       \
 	fi
 
 checkgoimports: ## checks that Go imports are formatted correctly
-	@@if [ -n "$$(${GO} run golang.org/x/tools/cmd/goimports -l -d -local csbbrokerpakazure .)" ]; then \
+	@@if [ -n "$$(go run golang.org/x/tools/cmd/goimports -l -d -local csbbrokerpakazure .)" ]; then \
 		echo "goimports check failed: run 'make format'";                      \
 		exit 1;                                                                \
 	fi
 
 vet: ## runs go vet
-	${GO} vet ./...
+	go vet ./...
 
 staticcheck: ## runs staticcheck
-	${GO} run honnef.co/go/tools/cmd/staticcheck ./...
+	go run honnef.co/go/tools/cmd/staticcheck ./...
 
 .PHONY: format
 format: ## format the source
-	${GOFMT} -s -e -l -w .
-	${GO} run golang.org/x/tools/cmd/goimports -l -w -local csbbrokerpakazure .
+	gofmt -s -e -l -w .
+	go run golang.org/x/tools/cmd/goimports -l -w -local csbbrokerpakazure .
 	terraform fmt --recursive
 
 ./providers/terraform-provider-csbmssqldbrunfailover/cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover:

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,11 @@ GO-VER = go$(GO-VERSION)
 CSB_VERSION := $(or $(CSB_VERSION), $(shell grep 'github.com/cloudfoundry/cloud-service-broker' go.mod | grep -v replace | awk '{print $$NF}' | sed -e 's/v//'))
 CSB_RELEASE_VERSION := $(CSB_VERSION)
 
-CSB_DOCKER_IMAGE := $(or $(CSB), cfplatformeng/csb:$(CSB_VERSION))
-GO_OK :=  $(or $(USE_GO_CONTAINERS), $(shell which go 1>/dev/null 2>/dev/null; echo $$?))
-DOCKER_OK := $(shell which docker 1>/dev/null 2>/dev/null; echo $$?)
-
 ####### broker environment variables
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), $(IAAS)-broker)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), $(IAAS)-broker-pw)
 GSB_PROVISION_DEFAULTS := $(or $(GSB_PROVISION_DEFAULTS), {"resource_group": "broker-cf-test"})
 
-ifeq ($(GO_OK), 0)
 GO=go
 GOFMT=gofmt
 BROKER_GO_OPTS=PORT=8080 \
@@ -41,34 +36,6 @@ RUN_CSB=$(BROKER_GO_OPTS) go run github.com/cloudfoundry/cloud-service-broker
 
 LDFLAGS="-X github.com/cloudfoundry/cloud-service-broker/utils.Version=$(CSB_VERSION)"
 GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) github.com/cloudfoundry/cloud-service-broker"
-else ifeq ($(DOCKER_OK), 0)
-BROKER_DOCKER_OPTS=--rm -v $(PAK_BUILD_CACHE_PATH):$(PAK_BUILD_CACHE_PATH) -v $(PWD):/brokerpak -w /brokerpak --network=host \
-	-p 8080:8080 \
-	-e SECURITY_USER_NAME \
-	-e SECURITY_USER_PASSWORD \
-	-e ARM_SUBSCRIPTION_ID \
-	-e ARM_TENANT_ID \
-	-e ARM_CLIENT_ID \
-	-e ARM_CLIENT_SECRET \
-	-e "DB_TYPE=sqlite3" \
-	-e "DB_PATH=/tmp/csb-db" \
-	-e "PAK_BUILD_CACHE_PATH=$(PAK_BUILD_CACHE_PATH)" \
-	-e GSB_PROVISION_DEFAULTS
-
-RUN_CSB=docker run $(BROKER_DOCKER_OPTS) $(CSB_DOCKER_IMAGE)
-
-#### running go inside a container, this is for integration tests and push-broker
-# path inside the container
-PAK_PATH=/brokerpak
-
-GO_DOCKER_OPTS=--rm -v $(PAK_BUILD_CACHE_PATH):$(PAK_BUILD_CACHE_PATH) -v $(PWD):/brokerpak -w /brokerpak --network=host
-GO=docker run $(GO_DOCKER_OPTS) golang:latest go
-GOFMT=docker run $(GO_DOCKER_OPTS) golang:latest gofmt
-
-GET_CSB="wget -O cloud-service-broker https://github.com/cloudfoundry/cloud-service-broker/releases/download/v$(CSB_RELEASE_VERSION)/cloud-service-broker.linux && chmod +x cloud-service-broker"
-else
-$(error either Go or Docker must be installed)
-endif
 
 ###### Targets ################################################################
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available make targets can be listed by running `make`.
 2. Launch an interactive shell into some supported image containing all necessary tools. For example:
    ```
    # From the root of this repo run:
-   docker run -it --rm -v "${PWD}:/repo" --workdir "/repo" --entrypoint "/bin/bash" cflondonservices/csb-ci-main
+   docker run -it --rm -v "${PWD}:/repo" --workdir "/repo" --entrypoint "/bin/bash" golang:latest
    make
    ```
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ A brokerpak for the [Cloud Service Broker](https://github.com/pivotal/cloud-serv
 
 ## Development Requirements
 
-* Either Go or [Docker](https://docs.docker.com/get-docker/)
+* Either an up-to-date version of Go or [Docker](https://docs.docker.com/get-docker/)
 * make - covers development lifecycle steps
-
-A docker container for the cloud service broker binary is available at *cfplatformeng/csb*
 
 ## Azure account information
 
@@ -29,14 +27,16 @@ Available make targets can be listed by running `make`.
 ### Running with docker
 
 1. Install [Docker](https://docs.docker.com/get-docker/)
-2. If you don't have Go installed, the makefile will automatically use Docker. If you do have go installed but still want to use docker, then set the `USE_GO_CONTAINERS` to `true`.
-
-Make targets will run with the *cfplatformeng/csb* docker image. Alternatively, a custom image can be specified by setting the `CSB` environment variable.
+2. Launch an interactive shell into some supported image containing all necessary tools. For example:
+   ```
+   # From the root of this repo run:
+   docker run -it --rm -v "${PWD}:/repo" --workdir "/repo" --entrypoint "/bin/bash" cflondonservices/csb-ci-main
+   make
+   ```
 
 ### Running with Go
 
 1. Make sure you have the right Go version installed (see `go.mod` file).
-2. Make sure `USE_GO_CONTAINERS` environment variable is ***NOT*** set.
 
 The make targets will build the source using the local go installation.
 

--- a/providers/terraform-provider-csbmssqldbrunfailover/Makefile
+++ b/providers/terraform-provider-csbmssqldbrunfailover/Makefile
@@ -2,15 +2,7 @@
 
 GO-VERSION = 1.22.0
 GO-VER = go$(GO-VERSION)
-GO_OK :=  $(or $(USE_GO_CONTAINERS), $(shell which go 1>/dev/null 2>/dev/null; echo $$?))
-DOCKER_OK := $(shell which docker 1>/dev/null 2>/dev/null; echo $$?)
-ifeq ($(GO_OK), 0)
   GO=go
-else ifeq ($(DOCKER_OK), 0)
-  GO=docker run --rm -v $(PWD)/../..:/src -w /src/providers/terraform-provider-csbmssqldbrunfailover -e GOARCH -e GOOS -e CGO_ENABLED golang:$(GO-VERSION) go
-else
-  $(error either Go or Docker must be installed)
-endif
 
 .PHONY: help
 help: ## list Makefile targets


### PR DESCRIPTION
The same benefits can be achieved by simply launching an interactive docker session inside a supported image and running commands from there. This approach has some additional benefits
- Easier to maintain
- Debloats Makefile
- Less hidden magic
- Same code for local and containerised execution

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

