### PR TITLE
chore: make codeql action use golang specified in go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,9 +24,6 @@ jobs:
         language: [ 'go' ]
 
     steps:
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.0'
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -41,6 +38,12 @@ jobs:
 
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: +security-and-quality
+
+    # Install golang used by this project (https://github.com/github/codeql-action/issues/1842)
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: "go.mod"
 
     - run: make build
 


### PR DESCRIPTION
Related PRs:
- https://github.com/argentumcode/systemd-failure-pagerduty/pull/8/files

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

