### PR TITLE
chore: specify go 1.22.0 in go.mod

### DIFF
--- a/acceptance-tests/apps/mongodbapp/go.mod
+++ b/acceptance-tests/apps/mongodbapp/go.mod
@@ -1,6 +1,6 @@
 module mongodbapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/mssqlapp/go.mod
+++ b/acceptance-tests/apps/mssqlapp/go.mod
@@ -1,6 +1,6 @@
 module mssqlapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/mysqlapp/go.mod
+++ b/acceptance-tests/apps/mysqlapp/go.mod
@@ -1,6 +1,6 @@
 module mysqlapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/postgresqlapp/go.mod
+++ b/acceptance-tests/apps/postgresqlapp/go.mod
@@ -1,6 +1,6 @@
 module postgresqlapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/redisapp/go.mod
+++ b/acceptance-tests/apps/redisapp/go.mod
@@ -1,6 +1,6 @@
 module redisapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module csbbrokerpakazure
 
-go 1.22
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/jsonry v1.1.4


### PR DESCRIPTION
Related PRs:
- https://github.com/cloudfoundry/csb-brokerpak-gcp/pull/1044

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

