### PR TITLE
chore: stop checking go version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ help: ## list Makefile targets
 
 ###### Setup ##################################################################
 IAAS=azure
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
 CSB_VERSION := $(or $(CSB_VERSION), $(shell grep 'github.com/cloudfoundry/cloud-service-broker' go.mod | grep -v replace | awk '{print $$NF}' | sed -e 's/v//'))
 CSB_RELEASE_VERSION := $(CSB_VERSION)
 
@@ -37,17 +35,8 @@ GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) 
 
 ###### Targets ################################################################
 
-.PHONY: deps-go-binary
-deps-go-binary:
-ifeq ($(SKIP_GO_VERSION_CHECK),)
-	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
-		exit 1; \
-	fi
-endif
-
 .PHONY: build
-build: deps-go-binary $(IAAS)-services-*.brokerpak ## build brokerpak
+build: $(IAAS)-services-*.brokerpak ## build brokerpak
 
 $(IAAS)-services-*.brokerpak: *.yml terraform/*/*.tf ./providers/terraform-provider-csbmssqldbrunfailover/cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover | $(PAK_BUILD_CACHE_PATH)
 	$(RUN_CSB) pak build

--- a/providers/terraform-provider-csbmssqldbrunfailover/Makefile
+++ b/providers/terraform-provider-csbmssqldbrunfailover/Makefile
@@ -1,14 +1,12 @@
 .DEFAULT_GOAL = help
 
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
   GO=go
 
 .PHONY: help
 help: ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build: deps-go-binary cloudfoundry.org ## build the provider
+build: cloudfoundry.org ## build the provider
 
 cloudfoundry.org: *.go */*.go
 	mkdir -p cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/1.0.0/linux_amd64
@@ -39,12 +37,3 @@ run-acceptance-tests-coverage: ## infrastructure tests coverage score
 	export TF_ACC=1; \
 	go test -coverpkg=`cat /tmp/tpmssqldbrunfailover-pkgs.txt` -coverprofile=/tmp/tpmssqldbrunfailover-coverage.out ./...
 	go tool cover -func /tmp/tpmssqldbrunfailover-coverage.out | grep total
-
-.PHONY: deps-go-binary
-deps-go-binary:
-ifeq ($(SKIP_GO_VERSION_CHECK),)
-	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
-		exit 1; \
-	fi
-endif


### PR DESCRIPTION
[#187027977](https://www.pivotaltracker.com/story/show/187027977)

Before Go 1.21:
- The go directive was advisory only; now it is a mandatory requirement
- The go directive didn't allow specifying patch versions

So, by specifying the patch version in go.mod:
- Noone can unknowingly test, run or build this project using an older version of go
- The required Go toolchain can be downloaded automatically

Therefore, checking the current go version in Makefile is no longer needed.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

