### PR TITLE
chore: workaround issue after bumping azurerm to v3.94.0

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -73,6 +73,9 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			By("checking previously written data still accessible")
 			Expect(appTwo.GET(key1)).To(Equal(value1))
 
+			By("updating the instance without changing the plan")
+			serviceInstance.Update("-c", `{"maxmemory_policy": "volatile-random"}`)
+
 			By("updating the instance plan")
 			serviceInstance.Update("-p", "deprecated-medium")
 


### PR DESCRIPTION
[#187172990]

Version 3.94.0 for terraform-provider-azurerm caused issues in redis acceptance_test/upgrade/update_and_upgrade_redis_test https://github.com/cloudfoundry/csb-brokerpak-azure/commit/e154a5dcb82cfa251efa0abbd8202d0c0e348a31

We were getting error:
> BadRequest: The following updates can't be processed in one
single request, please send separate request to update them: 'properties.sku.capacity,properties.aadEnableDisable'

This workaround doesn't fixes the problem, and we still don't fully understand what is the rootcause of the issue. Because of that, we prefer reverting the following commit until we can guarantee that customer instances won't fail or be blocked by this type of errors:
https://github.com/cloudfoundry/csb-brokerpak-azure/commit/e154a5dcb82cfa251efa0abbd8202d0c0e348a31

This commit is just a way of documenting the workaround with the hope that it can help future us better understand the root cause of the issue.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

