### PR TITLE
chore: revert bump 3.94.0 for azure provider

### DIFF
--- a/dependency-manifest.yml
+++ b/dependency-manifest.yml
@@ -18,9 +18,9 @@ dependencies:
       source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
       source_sha256: 67ceb2f009313c076a6bf8a063443da5ea97d75bac18fc22a6861e9f73712155
     - name: terraform-provider-azurerm
-      version: 3.94.0
-      source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.94.0.zip
-      source_sha256: e46bae6b1b4805ee32f6682a40948c2c15eac4a728b62a5971609fa938080cf4
+      version: 3.93.0
+      source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.93.0.zip
+      source_sha256: 547f3f6d119d80035f5f11e4166db689c2f8b0f479c099007982857014e03cda
     - name: terraform-provider-csbsqlserver
       version: 1.0.11
       source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.11.zip

--- a/manifest.yml
+++ b/manifest.yml
@@ -28,8 +28,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
   default: true  
 - name: terraform-provider-azurerm
-  version: 3.94.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.94.0.zip
+  version: 3.93.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.93.0.zip
 - name: terraform-provider-random
   version: 3.6.0
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.0.zip


### PR DESCRIPTION
[#187172990](https://www.pivotaltracker.com/story/show/187172990)

Version 3.94.0 for terraform-provider-azurerm caused issues in
redis acceptance_test/upgrade/update_and_upgrade_redis_test
https://github.com/cloudfoundry/csb-brokerpak-azure/commit/e154a5dcb82cfa251efa0abbd8202d0c0e348a31

We were getting error:
> BadRequest: The following updates can't be processed in one
single request, please send separate request to update them:
'properties.sku.capacity,properties.aadEnableDisable'

We still don't fully understand what is the root cause of the
issue. Because of that, **we prefer reverting the bump commit**
until we can guarantee that customer instances won't fail or be
blocked by this type of errors.

There is another PR with a workaround for the test, but take
into account that it doesn't fix the problem, and should be
used just as a way to document the issue with the hope that
it can help us better understand the root cause in the future.

https://github.com/cloudfoundry/csb-brokerpak-azure/pull/704

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

