### PR TITLE
chore: annotate sensitive terraform varaibles

### DIFF
--- a/azure-mssql-fog-run-failover.yml
+++ b/azure-mssql-fog-run-failover.yml
@@ -63,6 +63,7 @@ provision:
     default: false
   template_refs:
     versions: terraform/azure-mssql-db-failover/run-failover/run-failover-versions.tf
+    variables: terraform/azure-mssql-db-failover/run-failover/variables.tf
     providers: terraform/azure-mssql-db-failover/run-failover/run-failover-providers.tf
     main: terraform/azure-mssql-db-failover/run-failover/run-failover.tf
   computed_inputs: []

--- a/terraform/azure-cosmosdb/provision/variables.tf
+++ b/terraform/azure-cosmosdb/provision/variables.tf
@@ -1,7 +1,10 @@
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "skip_provider_registration" { type = bool }
 variable "instance_name" { type = string }
 variable "resource_group" { type = string }

--- a/terraform/azure-eventhubs/bind/variables.tf
+++ b/terraform/azure-eventhubs/bind/variables.tf
@@ -1,7 +1,10 @@
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "skip_provider_registration" { type = bool }
 variable "eventhub_rg_name" { type = string }
 variable "namespace_name" { type = string }

--- a/terraform/azure-eventhubs/provision/variables.tf
+++ b/terraform/azure-eventhubs/provision/variables.tf
@@ -1,7 +1,10 @@
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "skip_provider_registration" { type = bool }
 variable "instance_name" { type = string }
 variable "resource_group" { type = string }

--- a/terraform/azure-mongodb/provision/variables.tf
+++ b/terraform/azure-mongodb/provision/variables.tf
@@ -3,7 +3,10 @@ variable "instance_name" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "account_name" { type = string }
 variable "db_name" { type = string }
 variable "collection_name" { type = string }

--- a/terraform/azure-mssql-db-failover/azure-provider.tf
+++ b/terraform/azure-mssql-db-failover/azure-provider.tf
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "skip_provider_registration" { type = bool }
-
 provider "azurerm" {
   features {}
 

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-variables.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-variables.tf
@@ -1,5 +1,16 @@
+variable "azure_subscription_id" { type = string }
+variable "azure_client_id" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
+variable "azure_tenant_id" { type = string }
+variable "skip_provider_registration" { type = bool }
 variable "instance_name" { type = string }
-variable "server_credential_pairs" { type = map(any) }
+variable "server_credential_pairs" {
+  type      = map(any)
+  sensitive = true
+}
 variable "server_pair" { type = string }
 variable "db_name" { type = string }
 variable "labels" { type = map(any) }

--- a/terraform/azure-mssql-db-failover/run-failover/run-failover-providers.tf
+++ b/terraform/azure-mssql-db-failover/run-failover/run-failover-providers.tf
@@ -1,8 +1,3 @@
-variable "azure_tenant_id" { type = string }
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
-
 provider "csbmssqldbrunfailover" {
   azure_tenant_id       = var.azure_tenant_id
   azure_client_id       = var.azure_client_id

--- a/terraform/azure-mssql-db-failover/run-failover/variables.tf
+++ b/terraform/azure-mssql-db-failover/run-failover/variables.tf
@@ -1,4 +1,3 @@
-variable "instance_name" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
@@ -6,6 +5,3 @@ variable "azure_client_secret" {
   type      = string
   sensitive = true
 }
-variable "location" { type = string }
-variable "labels" { type = map(any) }
-variable "skip_provider_registration" { type = bool }

--- a/terraform/azure-mssql-db/bind/mssql-bind-variables.tf
+++ b/terraform/azure-mssql-db/bind/mssql-bind-variables.tf
@@ -16,6 +16,12 @@ variable "mssql_db_name" { type = string }
 variable "mssql_hostname" { type = string }
 variable "mssql_port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "server" { type = string }
-variable "server_credentials" { type = map(any) }
+variable "server_credentials" {
+  type      = map(any)
+  sensitive = true
+}

--- a/terraform/azure-mssql-db/provision/mssql-db-providers.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-providers.tf
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "azure_subscription_id" { type = string }
-variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
-variable "azure_tenant_id" { type = string }
-variable "skip_provider_registration" { type = bool }
-
 provider "azurerm" {
   features {}
 

--- a/terraform/azure-mssql-db/provision/mssql-db-variables.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-variables.tf
@@ -1,6 +1,17 @@
+variable "azure_subscription_id" { type = string }
+variable "azure_client_id" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
+variable "azure_tenant_id" { type = string }
+variable "skip_provider_registration" { type = bool }
 variable "db_name" { type = string }
 variable "server" { type = string }
-variable "server_credentials" { type = map(any) }
+variable "server_credentials" {
+  type      = map(any)
+  sensitive = true
+}
 variable "labels" { type = map(any) }
 variable "sku_name" { type = string }
 variable "cores" { type = number }

--- a/terraform/azure-mssql-failover/provision/variables.tf
+++ b/terraform/azure-mssql-failover/provision/variables.tf
@@ -2,7 +2,10 @@ variable "instance_name" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "resource_group" { type = string }
 variable "db_name" { type = string }
 variable "location" { type = string }

--- a/terraform/azure-mssql-server/provision/variables.tf
+++ b/terraform/azure-mssql-server/provision/variables.tf
@@ -2,10 +2,16 @@ variable "instance_name" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "resource_group" { type = string }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "location" { type = string }
 variable "labels" { type = map(any) }
 variable "authorized_network" { type = string }

--- a/terraform/azure-mssql/bind/variables.tf
+++ b/terraform/azure-mssql/bind/variables.tf
@@ -2,4 +2,7 @@ variable "mssql_db_name" { type = string }
 variable "mssql_hostname" { type = string }
 variable "mssql_port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/azure-mssql/provision/variables.tf
+++ b/terraform/azure-mssql/provision/variables.tf
@@ -5,7 +5,10 @@ variable "location" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "labels" { type = map(any) }
 variable "sku_name" { type = string }
 variable "cores" { type = number }

--- a/terraform/azure-mysql/bind/variables.tf
+++ b/terraform/azure-mysql/bind/variables.tf
@@ -2,5 +2,8 @@ variable "mysql_db_name" { type = string }
 variable "mysql_hostname" { type = string }
 variable "mysql_port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "use_tls" { type = bool }

--- a/terraform/azure-mysql/provision/variables.tf
+++ b/terraform/azure-mysql/provision/variables.tf
@@ -3,7 +3,10 @@ variable "resource_group" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "db_name" { type = string }
 variable "mysql_version" { type = string }
 variable "location" { type = string }

--- a/terraform/azure-postgres/bind/variables.tf
+++ b/terraform/azure-postgres/bind/variables.tf
@@ -2,5 +2,8 @@ variable "db_name" { type = string }
 variable "hostname" { type = string }
 variable "port" { type = number }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "use_tls" { type = bool }

--- a/terraform/azure-postgres/provision/variables.tf
+++ b/terraform/azure-postgres/provision/variables.tf
@@ -8,7 +8,10 @@ variable "resource_group" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "postgres_version" { type = string }
 variable "sku_name" { type = string }
 variable "authorized_network" { type = string }

--- a/terraform/azure-redis/provision/variables.tf
+++ b/terraform/azure-redis/provision/variables.tf
@@ -2,7 +2,10 @@ variable "resource_group" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "sku_name" { type = string }
 variable "redis_version" { type = string }
 variable "family" { type = string }

--- a/terraform/azure-storage/provision/variables.tf
+++ b/terraform/azure-storage/provision/variables.tf
@@ -7,6 +7,9 @@ variable "resource_group" { type = string }
 variable "azure_tenant_id" { type = string }
 variable "azure_subscription_id" { type = string }
 variable "azure_client_id" { type = string }
-variable "azure_client_secret" { type = string }
+variable "azure_client_secret" {
+  type      = string
+  sensitive = true
+}
 variable "skip_provider_registration" { type = bool }
 variable "authorized_networks" { type = list(string) }


### PR DESCRIPTION
By annotating terraform variables that contain sensitive information, we ensure that they are not printed out in error messages.

This re-implements #356 which previously had to be reverted due to not being supported by the version of terraform at the time. Note that we have not chosen to annotate IDs (e.g. user IDs) as sensitive, but only secrets/passwords. This is because printing out an ID in an error message can be very helpful.

[#183474479](https://www.pivotaltracker.com/story/show/183474479)
