### PR TITLE
chore: annotate sensitive terraform outputs

### DIFF
--- a/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
@@ -13,7 +13,10 @@ output "sqlServerFullyQualifiedDomainName" { value = format("%s.database.windows
 output "hostname" { value = format("%s.database.windows.net", var.existing ? var.instance_name : local.fog_name) }
 output "port" { value = 1433 }
 output "name" { value = var.existing ? var.db_name : local.primary_db_name }
-output "username" { value = var.server_credential_pairs[var.server_pair].admin_username }
+output "username" {
+  value     = var.server_credential_pairs[var.server_pair].admin_username
+  sensitive = true
+}
 output "password" {
   value     = var.server_credential_pairs[var.server_pair].admin_password
   sensitive = true
@@ -31,5 +34,7 @@ output "status" {
     local.primary_db_name, data.azurerm_sql_server.secondary_sql_db_server.id, local.primary_db_name,
     data.azurerm_sql_server.secondary_sql_db_server.name, data.azurerm_sql_server.secondary_sql_db_server.id,
     var.azure_tenant_id,
-  data.azurerm_sql_server.primary_sql_db_server.id)
+    data.azurerm_sql_server.primary_sql_db_server.id,
+  )
+  sensitive = true
 }

--- a/terraform/azure-mssql-db/provision/mssql-db-outputs.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-outputs.tf
@@ -3,12 +3,24 @@ locals {
 }
 
 output "sqldbName" { value = azurerm_mssql_database.azure_sql_db.name }
-output "sqlServerName" { value = data.azurerm_sql_server.azure_sql_db_server.name }
-output "sqlServerFullyQualifiedDomainName" { value = local.serverFQDN }
-output "hostname" { value = local.serverFQDN }
+output "sqlServerName" {
+  value     = data.azurerm_sql_server.azure_sql_db_server.name
+  sensitive = true
+}
+output "sqlServerFullyQualifiedDomainName" {
+  value     = local.serverFQDN
+  sensitive = true
+}
+output "hostname" {
+  value     = local.serverFQDN
+  sensitive = true
+}
 output "port" { value = 1433 }
 output "name" { value = azurerm_mssql_database.azure_sql_db.name }
-output "username" { value = var.server_credentials[var.server].admin_username }
+output "username" {
+  value     = var.server_credentials[var.server].admin_username
+  sensitive = true
+}
 output "password" {
   value     = var.server_credentials[var.server].admin_password
   sensitive = true


### PR DESCRIPTION
This follows on from #712, in which `var.server_credential_pairs` and `var.server_credentials` were annotates as sensitive as they contain passwords. An effect of this is that certain output which do not actually contain sensitive information are now tainted as sensitive as they are partially derived from a var that is now annotated as sensitive. To resolve this, we annotate those outputs as sensitive so as to avoid Terraform failing.

[#183474479](https://www.pivotaltracker.com/story/show/183474479)
