### PR TITLE
chore: Add labeler to improve the release notes. 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+# Add 'breaking-change' label to any PR where the head branch name starts with `!feat` 
+breaking-change:
+ - head-branch: ['^feat!']
+
+new-feature:
+ - head-branch: ['^feat']
+
+bug-fix:
+- head-branch: ['^fix']
+
+test-dependency-updates:
+- head-branch: ['dependabot/go_modules/acceptance-tests']
+
+dependency-updates:
+- head-branch: ['^.*(deps)']
+
+chore:
+- head-branch: ['^chore']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - test-dependency-updates
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - new-feature
+    - title: Bug fixes
+      labels:
+        - bug-fix
+    - title: Dependency updates
+      labels:
+        - dependency-updates
+        - dependencies
+    - title: Others
+      labels:
+        - chore
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Each PR will be labeled depending on the name of the branch according to convertional commits. The release notes will be clasified based on the type of PRs.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

