### PR TITLE
test: remove Chi dependency from test apps

### DIFF
--- a/acceptance-tests/apps/mongodbapp/go.mod
+++ b/acceptance-tests/apps/mongodbapp/go.mod
@@ -4,7 +4,6 @@ go 1.22.2
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/mitchellh/mapstructure v1.5.0
 	go.mongodb.org/mongo-driver v1.15.0
 )

--- a/acceptance-tests/apps/mongodbapp/go.sum
+++ b/acceptance-tests/apps/mongodbapp/go.sum
@@ -3,8 +3,6 @@ github.com/cloudfoundry-community/go-cfenv v1.18.0/go.mod h1:qGMSI6lygPzqugFs9M1
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/acceptance-tests/apps/mongodbapp/internal/app/app.go
+++ b/acceptance-tests/apps/mongodbapp/internal/app/app.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -21,19 +20,13 @@ const (
 func App(uri string) http.Handler {
 	client := connect(uri)
 
-	r := chi.NewRouter()
-	r.Head("/", aliveness)
-	r.Get("/", handleListDatabases(client))
-	r.Get("/{database}", handleListCollections(client))
-	r.Get("/{database}/{collection}/{document}", handleFetchDocument(client))
-	r.Put("/{database}/{collection}/{document}", handleStoreDocument(client))
+	r := http.NewServeMux()
+	r.HandleFunc("GET /", handleListDatabases(client))
+	r.HandleFunc("GET /{database}", handleListCollections(client))
+	r.HandleFunc("GET /{database}/{collection}/{document}", handleFetchDocument(client))
+	r.HandleFunc("PUT /{database}/{collection}/{document}", handleStoreDocument(client))
 
 	return r
-}
-
-func aliveness(w http.ResponseWriter, r *http.Request) {
-	log.Printf("Handled aliveness test.")
-	w.WriteHeader(http.StatusNoContent)
 }
 
 func connect(uri string) *mongo.Client {

--- a/acceptance-tests/apps/mongodbapp/internal/app/fetch_document.go
+++ b/acceptance-tests/apps/mongodbapp/internal/app/fetch_document.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -15,15 +13,15 @@ func handleFetchDocument(client *mongo.Client) func(w http.ResponseWriter, r *ht
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling fetch.")
 
-		databaseName := chi.URLParam(r, "database")
+		databaseName := r.PathValue("database")
 		if databaseName == "" {
 			fail(w, http.StatusBadRequest, "database name must be supplied")
 		}
-		collectionName := chi.URLParam(r, "collection")
+		collectionName := r.PathValue("collection")
 		if collectionName == "" {
 			fail(w, http.StatusBadRequest, "collection name must be supplied")
 		}
-		documentName := chi.URLParam(r, "document")
+		documentName := r.PathValue("document")
 		if documentName == "" {
 			fail(w, http.StatusBadRequest, "document name must be supplied")
 		}

--- a/acceptance-tests/apps/mongodbapp/internal/app/list_collections.go
+++ b/acceptance-tests/apps/mongodbapp/internal/app/list_collections.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -16,7 +14,7 @@ func handleListCollections(client *mongo.Client) func(w http.ResponseWriter, r *
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling list collections.")
 
-		databaseName := chi.URLParam(r, "database")
+		databaseName := r.PathValue("database")
 		if databaseName == "" {
 			fail(w, http.StatusBadRequest, "database name must be supplied")
 		}

--- a/acceptance-tests/apps/mongodbapp/internal/app/store_document.go
+++ b/acceptance-tests/apps/mongodbapp/internal/app/store_document.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -15,15 +13,15 @@ func handleStoreDocument(client *mongo.Client) func(w http.ResponseWriter, r *ht
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling store.")
 
-		databaseName := chi.URLParam(r, "database")
+		databaseName := r.PathValue("database")
 		if databaseName == "" {
 			fail(w, http.StatusBadRequest, "database name must be supplied")
 		}
-		collectionName := chi.URLParam(r, "collection")
+		collectionName := r.PathValue("collection")
 		if collectionName == "" {
 			fail(w, http.StatusBadRequest, "collection name must be supplied")
 		}
-		documentName := chi.URLParam(r, "document")
+		documentName := r.PathValue("document")
 		if documentName == "" {
 			fail(w, http.StatusBadRequest, "document name must be supplied")
 		}

--- a/acceptance-tests/apps/mssqlapp/go.mod
+++ b/acceptance-tests/apps/mssqlapp/go.mod
@@ -5,7 +5,6 @@ go 1.22.2
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
 	github.com/denisenkom/go-mssqldb v0.12.3
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/mitchellh/mapstructure v1.5.0
 )
 

--- a/acceptance-tests/apps/mssqlapp/go.sum
+++ b/acceptance-tests/apps/mssqlapp/go.sum
@@ -9,8 +9,6 @@ github.com/denisenkom/go-mssqldb v0.12.3 h1:pBSGx9Tq67pBOTLmxNuirNTeB8Vjmf886Kx+
 github.com/denisenkom/go-mssqldb v0.12.3/go.mod h1:k0mtMFOnU+AihqFxPMiF05rtiDrorD1Vrm1KEz5hxDo=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=

--- a/acceptance-tests/apps/mssqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/app.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	_ "github.com/denisenkom/go-mssqldb"
-	"github.com/go-chi/chi/v5"
 )
 
 const (
@@ -24,13 +23,13 @@ func App(config string) http.Handler {
 		log.Fatalf("failed to ping database: %s", err)
 	}
 
-	r := chi.NewRouter()
-	r.Head("/", aliveness)
-	r.Put("/{schema}", handleCreateSchema(config))
-	r.Post("/{schema}", handleFillDatabase(config))
-	r.Delete("/{schema}", handleDropSchema(config))
-	r.Put("/{schema}/{key}", handleSet(config))
-	r.Get("/{schema}/{key}", handleGet(config))
+	r := http.NewServeMux()
+	r.HandleFunc("HEAD /", aliveness)
+	r.HandleFunc("PUT /{schema}", handleCreateSchema(config))
+	r.HandleFunc("POST /{schema}", handleFillDatabase(config))
+	r.HandleFunc("DELETE /{schema}", handleDropSchema(config))
+	r.HandleFunc("PUT /{schema}/{key}", handleSet(config))
+	r.HandleFunc("GET /{schema}/{key}", handleGet(config))
 
 	return r
 }
@@ -50,7 +49,7 @@ func connect(config string) *sql.DB {
 }
 
 func schemaName(r *http.Request) (string, error) {
-	schema := chi.URLParam(r, "schema")
+	schema := r.PathValue("schema")
 
 	switch {
 	case schema == "":

--- a/acceptance-tests/apps/mssqlapp/internal/app/get.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/get.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 func handleGet(config string) func(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +18,7 @@ func handleGet(config string) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		key := chi.URLParam(r, "key")
+		key := r.PathValue("key")
 		if key == "" {
 			fail(w, http.StatusBadRequest, "key must be supplied")
 			return

--- a/acceptance-tests/apps/mssqlapp/internal/app/set.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/set.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 func handleSet(config string) func(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +19,7 @@ func handleSet(config string) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		key := chi.URLParam(r, "key")
+		key := r.PathValue("key")
 		if key == "" {
 			fail(w, http.StatusBadRequest, "key must be supplied")
 			return

--- a/acceptance-tests/apps/postgresqlapp/go.mod
+++ b/acceptance-tests/apps/postgresqlapp/go.mod
@@ -4,7 +4,6 @@ go 1.22.2
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/mitchellh/mapstructure v1.5.0
 )

--- a/acceptance-tests/apps/postgresqlapp/go.sum
+++ b/acceptance-tests/apps/postgresqlapp/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/go-chi/chi/v5"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -20,12 +19,12 @@ const (
 func App(uri string) http.Handler {
 	db := connect(uri)
 
-	r := chi.NewRouter()
-	r.Head("/", aliveness)
-	r.Put("/{schema}", handleCreateSchema(db))
-	r.Delete("/{schema}", handleDropSchema(db))
-	r.Put("/{schema}/{key}", handleSet(db))
-	r.Get("/{schema}/{key}", handleGet(db))
+	r := http.NewServeMux()
+	r.HandleFunc("GET /", aliveness)
+	r.HandleFunc("PUT /{schema}", handleCreateSchema(db))
+	r.HandleFunc("DELETE /{schema}", handleDropSchema(db))
+	r.HandleFunc("PUT /{schema}/{key}", handleSet(db))
+	r.HandleFunc("GET /{schema}/{key}", handleGet(db))
 
 	return r
 }
@@ -45,7 +44,7 @@ func connect(uri string) *sql.DB {
 }
 
 func schemaName(r *http.Request) (string, error) {
-	schema := chi.URLParam(r, "schema")
+	schema := r.PathValue("schema")
 
 	switch {
 	case schema == "":

--- a/acceptance-tests/apps/postgresqlapp/internal/app/get.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/get.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 func handleGet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
@@ -19,7 +17,7 @@ func handleGet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		key := chi.URLParam(r, "key")
+		key := r.PathValue("key")
 		if key == "" {
 			fail(w, http.StatusBadRequest, "key name must be supplied")
 			return

--- a/acceptance-tests/apps/postgresqlapp/internal/app/set.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/set.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 func handleSet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +18,7 @@ func handleSet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		key := chi.URLParam(r, "key")
+		key := r.PathValue("key")
 		if key == "" {
 			fail(w, http.StatusBadRequest, "key name must be supplied")
 			return


### PR DESCRIPTION
Go 1.22 has an improved HTTP router that means we don't need the Chi router any more.

The Go 1.22 routing automatically adds a HEAD handler to every path that has a GET handler, so where we used to explicitly handle both methods we now only add the GET explicitly.

[#187470327](https://www.pivotaltracker.com/story/show/187470327)
