### PR TITLE
test: http method correction for mssql app

### DIFF
--- a/acceptance-tests/apps/mssqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/app.go
@@ -24,7 +24,7 @@ func App(config string) http.Handler {
 	}
 
 	r := http.NewServeMux()
-	r.HandleFunc("HEAD /", aliveness)
+	r.HandleFunc("GET /", aliveness)
 	r.HandleFunc("PUT /{schema}", handleCreateSchema(config))
 	r.HandleFunc("POST /{schema}", handleFillDatabase(config))
 	r.HandleFunc("DELETE /{schema}", handleDropSchema(config))


### PR DESCRIPTION
Fixes error:
```
panic: pattern "GET /{schema}/{key}" (registered at /tmp/build/17f8294a/brokerpak/acceptance-tests/apps/mssqlapp/internal/app/app.go:32) conflicts with pattern "HEAD /" (registered at /tmp/build/17f8294a/brokerpak/acceptance-tests/apps/mssqlapp/internal/app/app.go:27):
GET /{schema}/{key} matches more methods than HEAD /, but has a more specific path pattern
```

