### PR TITLE
test: delete hard-code instance name

### DIFF
--- a/azure-mssql-server.yml
+++ b/azure-mssql-server.yml
@@ -159,5 +159,5 @@ examples:
 - name: azuresql-db-server-standard-admin-username-password
   description: Create a standard Azure SQL Database Server with instance name, admin username and admin password
   plan_id: 1aab10e2-ca79-4755-855a-6073a739d2e0
-  provision_params: {"instance_name": "a-test-instance", "admin_username": "anadmin", "admin_password": "SomeComp-l1cat3d_Passw0rd"}
+  provision_params: {"admin_username": "anadmin", "admin_password": "SomeComp-l1cat3d_Passw0rd"}
   bind_params: {}  


### PR DESCRIPTION
The instance name is hard-coded in the example test. This causes a conflict when retrying the test after a failure because the test creates a resource group infrastructure element before creating the MSSQL server. This results in an error when attempting to create the same resource group: "resource group already exists." By removing the hard-coded instance name, we can generate a random instance name and resource group name to avoid this problem.

[#184671744](https://www.pivotaltracker.com/story/show/184671744)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

