### PR TITLE
chore: Retire MySQL and PostgreSQL services

### DIFF
--- a/azure-mysql.yml
+++ b/azure-mysql.yml
@@ -15,8 +15,8 @@
 version: 1
 name: csb-azure-mysql
 id: cac4a46b-c4ec-49df-9b11-06457a29d31e
-description: Retired - Azure Database for MySQL servers
-display_name: Retired - Azure Database for MySQL servers
+description: Retired - Azure Database for MySQL single servers
+display_name: Retired - Azure Database for MySQL single servers
 image_url: file://service-images/csb.png
 documentation_url: https://learn.microsoft.com/en-gb/azure/mysql/single-server/single-server-overview
 support_url: https://learn.microsoft.com/en-gb/azure/mysql/single-server/single-server-overview

--- a/azure-mysql.yml
+++ b/azure-mysql.yml
@@ -15,12 +15,12 @@
 version: 1
 name: csb-azure-mysql
 id: cac4a46b-c4ec-49df-9b11-06457a29d31e
-description: Azure Database for MySQL servers
-display_name: Azure Database for MySQL servers
+description: Retired - Azure Database for MySQL servers
+display_name: Retired - Azure Database for MySQL servers
 image_url: file://service-images/csb.png
-documentation_url: https://docs.microsoft.com/en-us/azure/mysql/
-support_url: https://docs.microsoft.com/en-us/azure/mysql/
-tags: [azure, mysql, preview]
+documentation_url: https://learn.microsoft.com/en-gb/azure/mysql/single-server/single-server-overview
+support_url: https://learn.microsoft.com/en-gb/azure/mysql/single-server/single-server-overview
+tags: [azure, mysql, preview, retired, single server]
 plan_updateable: true
 plans:
 - name: small

--- a/azure-postgresql.yml
+++ b/azure-postgresql.yml
@@ -15,8 +15,8 @@
 version: 1
 name: csb-azure-postgresql
 id: ef89bc54-299a-4384-9dd6-4ea0cca11700
-description: Retired - Azure Database for PostgreSQL
-display_name: Retired - Azure Database for PostgreSQL
+description: Retired - Azure Database for PostgreSQL single servers
+display_name: Retired - Azure Database for PostgreSQL single servers
 image_url: file://service-images/csb.png
 documentation_url: https://learn.microsoft.com/en-gb/azure/postgresql/single-server/overview-single-server
 support_url: https://learn.microsoft.com/en-gb/azure/postgresql/single-server/overview-single-server

--- a/azure-postgresql.yml
+++ b/azure-postgresql.yml
@@ -15,12 +15,12 @@
 version: 1
 name: csb-azure-postgresql
 id: ef89bc54-299a-4384-9dd6-4ea0cca11700
-description: Azure Database for PostgreSQL
-display_name: Azure Database for PostgreSQL
+description: Retired - Azure Database for PostgreSQL
+display_name: Retired - Azure Database for PostgreSQL
 image_url: file://service-images/csb.png
-documentation_url: https://azure.microsoft.com/en-us/services/postgresql/
-support_url: https://azure.microsoft.com/en-us/services/postgresql/
-tags: [azure, postgresql, postgres, preview]
+documentation_url: https://learn.microsoft.com/en-gb/azure/postgresql/single-server/overview-single-server
+support_url: https://learn.microsoft.com/en-gb/azure/postgresql/single-server/overview-single-server
+tags: [azure, postgresql, postgres, preview, retired, single server]
 plan_updateable: true
 plans:
 - name: small

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -12,8 +12,8 @@ const (
 	mysqlServiceID               = "cac4a46b-c4ec-49df-9b11-06457a29d31e"
 	mysqlServiceDisplayName      = "Retired - Azure Database for MySQL single servers"
 	mysqlServiceDescription      = "Retired - Azure Database for MySQL single servers"
-	mysqlServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/mysql/"
-	mysqlServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/mysql/"
+	mysqlServiceDocumentationURL = "https://learn.microsoft.com/en-gb/azure/mysql/single-server/single-server-overview"
+	mysqlServiceSupportURL       = "https://learn.microsoft.com/en-gb/azure/mysql/single-server/single-server-overview"
 )
 
 var _ = Describe("MySQL", Label("MySQL"), func() {

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -32,7 +32,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 		service := testframework.FindService(catalog, mysqlServiceName)
 		Expect(service.ID).To(Equal(mysqlServiceID))
 		Expect(service.Description).To(Equal(mysqlServiceDescription))
-		Expect(service.Tags).To(ConsistOf("azure", "mysql", "preview"))
+		Expect(service.Tags).To(ConsistOf("azure", "mysql", "preview", "retired", "single server"))
 		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
 		Expect(service.Metadata.DisplayName).To(Equal(mysqlServiceDisplayName))
 		Expect(service.Metadata.DocumentationUrl).To(Equal(mysqlServiceDocumentationURL))

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -10,8 +10,8 @@ import (
 const (
 	mysqlServiceName             = "csb-azure-mysql"
 	mysqlServiceID               = "cac4a46b-c4ec-49df-9b11-06457a29d31e"
-	mysqlServiceDisplayName      = "Azure Database for MySQL servers"
-	mysqlServiceDescription      = "Azure Database for MySQL servers"
+	mysqlServiceDisplayName      = "Retired - Azure Database for MySQL single servers"
+	mysqlServiceDescription      = "Retired - Azure Database for MySQL single servers"
 	mysqlServiceDocumentationURL = "https://docs.microsoft.com/en-us/azure/mysql/"
 	mysqlServiceSupportURL       = "https://docs.microsoft.com/en-us/azure/mysql/"
 )

--- a/integration-tests/postgre_sql_test.go
+++ b/integration-tests/postgre_sql_test.go
@@ -32,7 +32,7 @@ var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {
 		service := testframework.FindService(catalog, postgreSQLServiceName)
 		Expect(service.ID).To(Equal(postgreSQLServiceID))
 		Expect(service.Description).To(Equal(postgreSQLServiceDescription))
-		Expect(service.Tags).To(ConsistOf("azure", "postgresql", "postgres", "preview"))
+		Expect(service.Tags).To(ConsistOf("azure", "postgresql", "postgres", "preview", "retired", "single server"))
 		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
 		Expect(service.Metadata.DisplayName).To(Equal(postgreSQLServiceDisplayName))
 		Expect(service.Metadata.DocumentationUrl).To(Equal(postgreSQLServiceDocumentationURL))

--- a/integration-tests/postgre_sql_test.go
+++ b/integration-tests/postgre_sql_test.go
@@ -10,8 +10,8 @@ import (
 const (
 	postgreSQLServiceName             = "csb-azure-postgresql"
 	postgreSQLServiceID               = "ef89bc54-299a-4384-9dd6-4ea0cca11700"
-	postgreSQLServiceDisplayName      = "Azure Database for PostgreSQL"
-	postgreSQLServiceDescription      = "Azure Database for PostgreSQL"
+	postgreSQLServiceDisplayName      = "Retired - Azure Database for PostgreSQL single servers"
+	postgreSQLServiceDescription      = "Retired - Azure Database for PostgreSQL single servers"
 	postgreSQLServiceDocumentationURL = "https://azure.microsoft.com/en-us/services/postgresql/"
 	postgreSQLServiceSupportURL       = "https://azure.microsoft.com/en-us/services/postgresql/"
 )

--- a/integration-tests/postgre_sql_test.go
+++ b/integration-tests/postgre_sql_test.go
@@ -12,8 +12,8 @@ const (
 	postgreSQLServiceID               = "ef89bc54-299a-4384-9dd6-4ea0cca11700"
 	postgreSQLServiceDisplayName      = "Retired - Azure Database for PostgreSQL single servers"
 	postgreSQLServiceDescription      = "Retired - Azure Database for PostgreSQL single servers"
-	postgreSQLServiceDocumentationURL = "https://azure.microsoft.com/en-us/services/postgresql/"
-	postgreSQLServiceSupportURL       = "https://azure.microsoft.com/en-us/services/postgresql/"
+	postgreSQLServiceDocumentationURL = "https://learn.microsoft.com/en-gb/azure/postgresql/single-server/overview-single-server"
+	postgreSQLServiceSupportURL       = "https://learn.microsoft.com/en-gb/azure/postgresql/single-server/overview-single-server"
 )
 
 var _ = Describe("PostgreSQL", Label("PostgreSQL"), func() {


### PR DESCRIPTION
Both services are on the retirement path from Azure and should no longer be used to create new instances. They will be replaced by flexible server offerings.

https://learn.microsoft.com/en-gb/azure/postgresql/single-server/whats-happening-to-postgresql-single-server
https://learn.microsoft.com/en-gb/azure/mysql/single-server/whats-happening-to-mysql-single-server

[#187634075](https://www.pivotaltracker.com/story/show/187634075)

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

