### PR TITLE
chore: drop the uuid dependency

### DIFF
--- a/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/resource_run_failover_test.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover/resource_run_failover_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/cloudfoundry/csb-brokerpak-azure/terraform-provider-csbmssqldbrunfailover/csbmssqldbrunfailover"
 	"github.com/cloudfoundry/csb-brokerpak-azure/terraform-provider-csbmssqldbrunfailover/testhelpers"
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -44,13 +43,13 @@ var _ = Describe("resource_run_failover resource", Ordered, Label("acceptance"),
 		var err error
 
 		config = testhelpers.FailoverConfig{
-			ResourceGroupName:     fmt.Sprintf("resourcegroupname-%s", uuid.NewString()),
-			ServerName:            fmt.Sprintf("servername-%s", uuid.NewString()),
+			ResourceGroupName:     testhelpers.RandomName("resourcegroupname"),
+			ServerName:            testhelpers.RandomName("servername"),
 			MainLocation:          "eastus",
 			PartnerServerLocation: "eastus2",
-			PartnerServerName:     fmt.Sprintf("partnerservername-%s", uuid.NewString()),
+			PartnerServerName:     testhelpers.RandomName("partnerservername"),
 			SubscriptionID:        azureSubscriptionID,
-			FailoverGroupName:     fmt.Sprintf("failovergroupname-%s", uuid.NewString()),
+			FailoverGroupName:     testhelpers.RandomName("failovergroupname"),
 		}
 
 		failoverData, err = testhelpers.CreateFailoverGroup(config)

--- a/providers/terraform-provider-csbmssqldbrunfailover/go.mod
+++ b/providers/terraform-provider-csbmssqldbrunfailover/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
@@ -27,6 +26,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/providers/terraform-provider-csbmssqldbrunfailover/testhelpers/failover.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/testhelpers/failover.go
@@ -3,14 +3,12 @@ package testhelpers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
-	"github.com/google/uuid"
 )
 
 type FailoverData struct {
@@ -92,8 +90,8 @@ func createServer(ctx context.Context, cred azcore.TokenCredential, resourceGrou
 		armsql.Server{
 			Location: to.Ptr(location),
 			Properties: &armsql.ServerProperties{
-				AdministratorLogin:         to.Ptr(fmt.Sprintf("dummylogin-%s", uuid.NewString())),
-				AdministratorLoginPassword: to.Ptr(fmt.Sprintf("dummyPassword-%s", uuid.NewString())),
+				AdministratorLogin:         to.Ptr(RandomName("dummylogin")),
+				AdministratorLoginPassword: to.Ptr(RandomName("dummyPassword")),
 			},
 		},
 		nil,

--- a/providers/terraform-provider-csbmssqldbrunfailover/testhelpers/random.go
+++ b/providers/terraform-provider-csbmssqldbrunfailover/testhelpers/random.go
@@ -1,0 +1,25 @@
+package testhelpers
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func RandomName(prefix string) string {
+	GinkgoHelper()
+
+	return fmt.Sprintf("%s-%s", prefix, RandomHex())
+}
+
+func RandomHex() string {
+	GinkgoHelper()
+
+	const length = 20
+	buf := make([]byte, length/2)
+	_, err := rand.Read(buf)
+	Expect(err).NotTo(HaveOccurred())
+	return fmt.Sprintf("%x", buf)
+}


### PR DESCRIPTION
Following on from commit 965ad7cec5187a9f093a7df33c7dace2b28351ca, it was observed that it's possible to completely drop a dependency on a uuid generation package

