### PR TITLE
test: enable running against tile based deployment

### DIFF
--- a/acceptance-tests/helpers/brokers/default.go
+++ b/acceptance-tests/helpers/brokers/default.go
@@ -25,7 +25,7 @@ func DefaultBrokerName() string {
 
 	username := os.Getenv("USER")
 	for _, n := range receiver.Names {
-		if n == "broker-cf-test" {
+		if n == "broker-cf-test" || n == "cloud-service-broker-azure" {
 			defaultBrokerName = n
 			return n
 		}


### PR DESCRIPTION
currently running these tests against as tile based deployment errors with:

```
• [PANICKED] [0.236 seconds]
Redis [It] can be accessed by an app [redis]
/tmp/build/135320cb/brokerpak/acceptance-tests/redis_test.go:14

  [PANICKED] Test Panicked
  In [It] at: /tmp/build/135320cb/brokerpak/acceptance-tests/helpers/brokers/default.go:39 @ 06/21/24 08:58:01.135

  could not determine default broker name

  Full Stack Trace
```

it seems that this is caused by the brokerpak tests expecting the name being set to `broker-cf-test`. The new broker is called `cloud-service-broker-azure` in a tile deployment and thus the tests panic.

[#187498188]

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

