### PR TITLE
test: force the environment variable

### DIFF
--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -31,7 +31,7 @@ func (b Broker) env() []apps.EnvVar {
 		switch {
 		case ok:
 			result = append(result, apps.EnvVar{Name: name, Value: val})
-		case !ok && required:
+		case required:
 			ginkgo.Fail(fmt.Sprintf("You must set the %s environment variable", name))
 		}
 	}
@@ -45,6 +45,7 @@ func (b Broker) env() []apps.EnvVar {
 		apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: true},
 		apps.EnvVar{Name: "TERRAFORM_UPGRADES_ENABLED", Value: true},
 		apps.EnvVar{Name: "CSB_DISABLE_TF_UPGRADE_PROVIDER_RENAMES", Value: true},
+		apps.EnvVar{Name: "GSB_COMPATIBILITY_ENABLE_GCP_DEPRECATED_SERVICES", Value: true},
 	)
 
 	return append(result, b.envExtras...)

--- a/scripts/push-broker.sh
+++ b/scripts/push-broker.sh
@@ -98,6 +98,10 @@ if [[ ${ENCRYPTION_PASSWORDS} ]]; then
   echo "    ENCRYPTION_PASSWORDS: $(echo "$ENCRYPTION_PASSWORDS" | jq @json)" >>$cfmf
 fi
 
+if [[ ${GSB_COMPATIBILITY_ENABLE_GCP_DEPRECATED_SERVICES} ]]; then
+  echo "    GSB_COMPATIBILITY_ENABLE_GCP_DEPRECATED_SERVICES: $(echo "$GSB_COMPATIBILITY_ENABLE_GCP_DEPRECATED_SERVICES" | jq @json)" >>$cfmf
+fi
+
 cf push --no-start -f "${cfmf}" --var app=${APP_NAME}
 
 if [[ -z ${MSYQL_INSTANCE} ]]; then


### PR DESCRIPTION
The new environment variable is not automatically read from the .envrc file by our implemented GoLang logic when creating a new broker in our acceptance tests.

[#187918632](https://www.pivotaltracker.com/story/show/187918632)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

