### PR TITLE
feat: use operator ~> as version constraint

### DIFF
--- a/terraform/azure-eventhubs/bind/versions.tf
+++ b/terraform/azure-eventhubs/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-eventhubs/provision/versions.tf
+++ b/terraform/azure-eventhubs/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-mssql-db-failover/azure-versions.tf
+++ b/terraform/azure-mssql-db-failover/azure-versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-mssql-db/bind/mssql-bind-versions.tf
+++ b/terraform/azure-mssql-db/bind/mssql-bind-versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
 
     csbsqlserver = {

--- a/terraform/azure-mssql-db/provision/mssql-db-versions.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
 
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-mssql-failover/provision/versions.tf
+++ b/terraform/azure-mssql-failover/provision/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-mssql-server/provision/versions.tf
+++ b/terraform/azure-mssql-server/provision/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-mssql/bind/versions.tf
+++ b/terraform/azure-mssql/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
     csbsqlserver = {
       source  = "cloudfoundry.org/cloud-service-broker/csbsqlserver"

--- a/terraform/azure-mssql/provision/versions.tf
+++ b/terraform/azure-mssql/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"

--- a/terraform/azure-postgresql-flexible-server/bind/versions.tf
+++ b/terraform/azure-postgresql-flexible-server/bind/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-postgresql-flexible-server/provision/versions.tf
+++ b/terraform/azure-postgresql-flexible-server/provision/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-redis/provision/versions.tf
+++ b/terraform/azure-redis/provision/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-resource-group/provision/versions.tf
+++ b/terraform/azure-resource-group/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-storage/provision/versions.tf
+++ b/terraform/azure-storage/provision/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.3.1"
+      version = "~> 3"
     }
   }
 }


### PR DESCRIPTION
The operator is a convenient shorthand that allows the rightmost component of a version to increment. The fix also corrects the Terraform test by downloading the current provider version.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

