### PR TITLE
test: use pre-existing resource groups

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
@@ -28,9 +28,6 @@ var _ = Describe("UpgradeMongoTest", Label("mongodb"), func() {
 			)
 			defer serviceBroker.Delete()
 
-			By("creating a resource group")
-			az.Start("group", "create", "--name", metadata.ResourceGroup, "--location", defaultRegion)
-
 			By("creating a service instance")
 			databaseName := random.Name(random.WithPrefix("database"))
 			collectionName := random.Name(random.WithPrefix("collection"))

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -37,9 +37,6 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			)
 			defer serviceBroker.Delete()
 
-			By("creating a resource group")
-			az.Start("group", "create", "--name", metadata.ResourceGroup, "--location", defaultRegion)
-
 			By("creating a service")
 			serviceInstance := services.CreateInstance(
 				"csb-azure-redis",

--- a/acceptance-tests/upgrade/upgrade_suite_test.go
+++ b/acceptance-tests/upgrade/upgrade_suite_test.go
@@ -21,10 +21,6 @@ var (
 	subscriptionID        string
 )
 
-const (
-	defaultRegion = "westus2"
-)
-
 func init() {
 	flag.StringVar(&fromVersion, "from-version", "", "version to upgrade from")
 	flag.StringVar(&releasedBuildDir, "releasedBuildDir", "", "location of released version of built broker and brokerpak")


### PR DESCRIPTION
The contract between CI infrastructure and the tests has historically been that resource groups will be provided. This undoes a change that was made to create a resource group in the test, which does not allow tests to run in parallel because they create the same resource group.