### PR TITLE
test: rename test helper to reflect what it does

### DIFF
--- a/acceptance-tests/helpers/az/start.go
+++ b/acceptance-tests/helpers/az/start.go
@@ -11,11 +11,10 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-func Start(args ...string) *gexec.Session {
+func Run(args ...string) {
 	GinkgoWriter.Printf("Running: az %s\n", strings.Join(args, " "))
 	command := exec.Command("az", args...)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session).WithTimeout(time.Hour).Should(gexec.Exit(0))
-	return session
 }

--- a/acceptance-tests/helpers/az/start.go
+++ b/acceptance-tests/helpers/az/start.go
@@ -12,6 +12,8 @@ import (
 )
 
 func Run(args ...string) {
+	GinkgoHelper()
+
 	GinkgoWriter.Printf("Running: az %s\n", strings.Join(args, " "))
 	command := exec.Command("az", args...)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)

--- a/acceptance-tests/mongodb_test.go
+++ b/acceptance-tests/mongodb_test.go
@@ -34,7 +34,7 @@ var _ = Describe("MongoDB", Label("mongodb"), func() {
 
 		By("changing the firewall to allow comms")
 		serviceName := fmt.Sprintf("csb%s", serviceInstance.GUID())
-		az.Start("cosmosdb", "update", "--ip-range-filter", metadata.PublicIP, "--name", serviceName, "--resource-group", metadata.ResourceGroup)
+		az.Run("cosmosdb", "update", "--ip-range-filter", metadata.PublicIP, "--name", serviceName, "--resource-group", metadata.ResourceGroup)
 
 		By("pushing the unstarted app twice")
 		appOne := apps.Push(apps.WithApp(apps.MongoDB))

--- a/acceptance-tests/redis_test.go
+++ b/acceptance-tests/redis_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Redis", Label("redis"), func() {
 
 		By("updating the firewall to allow comms")
 		serviceName := fmt.Sprintf("csb-redis-%s", serviceInstance.GUID())
-		az.Start("redis",
+		az.Run("redis",
 			"firewall-rules",
 			"create",
 			"--name", serviceName,

--- a/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func updateMongoFirewall(serviceName, resourceGroup, publicIP string) {
-	az.Start("cosmosdb", "update", "--ip-range-filter", publicIP, "--name", serviceName, "--resource-group", resourceGroup)
+	az.Run("cosmosdb", "update", "--ip-range-filter", publicIP, "--name", serviceName, "--resource-group", resourceGroup)
 }
 
 var _ = Describe("UpgradeMongoTest", Label("mongodb"), func() {

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func updateRedisFirewall(serviceName, resourceGroup, publicIP string) {
-	az.Start("redis",
+	az.Run("redis",
 		"firewall-rules",
 		"create",
 		"--name", serviceName,


### PR DESCRIPTION
The az.Start() helper actually waited for a command to finish