### PR TITLE
Revert "build(deps): bump Azure terraform provider to v4 (#888)"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -33,8 +33,8 @@ terraform_binaries:
   source: https://github.com/opentofu/opentofu/archive/v1.8.6.zip
   default: true
 - name: terraform-provider-azurerm
-  version: 4.12.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v4.12.0.zip
+  version: 3.117.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.117.0.zip
 - name: terraform-provider-random
   version: 3.6.3
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.3.zip

--- a/terraform/azure-mongodb/provision/versions.tf
+++ b/terraform/azure-mongodb/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"

--- a/terraform/azure-mssql-db-failover/azure-versions.tf
+++ b/terraform/azure-mssql-db-failover/azure-versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-mssql-db/provision/mssql-db-versions.tf
+++ b/terraform/azure-mssql-db/provision/mssql-db-versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/azure-redis/provision/versions.tf
+++ b/terraform/azure-redis/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 3"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"


### PR DESCRIPTION
This reverts commit 85fab72aa084cfba9bcc0aa321d763142cc4952b.

Sometimes updating a major version "just works" but in this case a lot of tests failed, so we need to take time to test every service manually
