### PR TITLE
chore: Fixes broker 'failed to allocate' test errors

### DIFF
--- a/acceptance-tests/helpers/services/delete.go
+++ b/acceptance-tests/helpers/services/delete.go
@@ -8,11 +8,15 @@ import (
 )
 
 func (s *ServiceInstance) Delete() {
+	Delete(s.Name)
+}
+
+func Delete(name string) {
 	switch cf.Version() {
 	case cf.VersionV8:
-		deleteWithWait(s.Name)
+		deleteWithWait(name)
 	default:
-		deleteWithPoll(s.Name)
+		deleteWithPoll(name)
 	}
 }
 

--- a/acceptance-tests/mssql_server_and_db_test.go
+++ b/acceptance-tests/mssql_server_and_db_test.go
@@ -48,11 +48,20 @@ var _ = Describe("MSSQL Server and DB", Label("mssql-db"), func() {
 		}()
 
 		By("creating a database in the server")
+		serviceOffering := "csb-azure-mssql-db"
+		servicePlan := "small"
+		serviceName := random.Name(random.WithPrefix(serviceOffering, servicePlan))
+		// CreateInstance can fail and can leave a service record (albeit a failed one) lying around.
+		// We can't delete service brokers that have serviceInstances, so we need to ensure the service instance
+		// is cleaned up regardless as to whether it wa successful. This is important when we use our own service broker
+		// (which can only have 5 instances at any time) to prevent subsequent test failures.
+		defer services.Delete(serviceName)
 		dbInstance := services.CreateInstance(
-			"csb-azure-mssql-db",
-			"small",
+			serviceOffering,
+			servicePlan,
 			services.WithBroker(serviceBroker),
 			services.WithParameters(map[string]string{"server": serverTag}),
+			services.WithName(serviceName),
 		)
 		defer dbInstance.Delete()
 


### PR DESCRIPTION
We can only have 5 instances of our test broker running. Tests that use the test broker can see 'failed to allocate' errors. This is because in the case of a failed creation of a service in our tests will fail to clean up the test broker, causing other test runs to fail.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

