### PR TITLE
feat: replace "azurerm_sql_failover_group" with "azurerm_mssql_failov…

### DIFF
--- a/acceptance-tests/helpers/apps/http.go
+++ b/acceptance-tests/helpers/apps/http.go
@@ -34,6 +34,16 @@ func (a *App) GET(format string, s ...any) string {
 	return string(data)
 }
 
+func (a *App) GETResponse(format string, s ...any) *http.Response {
+	GinkgoHelper()
+
+	url := a.urlf(format, s...)
+	GinkgoWriter.Printf("HTTP GET: %s\n", url)
+	response, err := http.Get(url)
+	Expect(err).NotTo(HaveOccurred())
+	return response
+}
+
 func (a *App) PUT(data, format string, s ...any) {
 	url := a.urlf(format, s...)
 	GinkgoWriter.Printf("HTTP PUT: %s\n", url)

--- a/acceptance-tests/mssql_server_pair_and_fog_db_test.go
+++ b/acceptance-tests/mssql_server_pair_and_fog_db_test.go
@@ -2,6 +2,7 @@ package acceptance_test
 
 import (
 	"context"
+	"fmt"
 
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
@@ -96,9 +97,11 @@ var _ = Describe("MSSQL Server Pair and Failover Group DB", Label("mssql-db-fail
 			runFailoverServicePlan,
 			services.WithBroker(serviceBroker),
 			services.WithParameters(map[string]any{
-				"server_pair_name":  serversConfig.ServerPairTag,
-				"server_pairs":      serversConfig.ServerPairsConfig(),
-				"fog_instance_name": fogName,
+				"server_pair_name": serversConfig.ServerPairTag,
+				"server_pairs":     serversConfig.ServerPairsConfig(),
+				// We now append a "-g" to the instance name as we replace the "azurerm_sql_failover_group"
+				// resource with the "azurerm_mssql_failover_group" to avoid name clashes.
+				"fog_instance_name": fmt.Sprintf("%s-g", fogName),
 			}),
 			services.WithName(serviceNameStandard),
 		)

--- a/azure-mssql-db-failover-group.yml
+++ b/azure-mssql-db-failover-group.yml
@@ -70,7 +70,7 @@ provision:
     details: Maximum storage allocated to the database instance in GB
   - field_name: instance_name
     type: string
-    details: Name for your Azure SQL Failover Group
+    details: Name for your Azure SQL Failover Group. Note that the resource name in Azure will have "-g" appended.
     default: csb-azsql-fog-${request.instance_id}
     constraints:
       maxLength: 63

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
@@ -40,12 +40,15 @@ resource "azurerm_mssql_database" "secondary_db" {
   count                       = var.existing ? 0 : 1
 }
 
-resource "azurerm_sql_failover_group" "failover_group" {
-  name                = var.instance_name
-  resource_group_name = var.server_credential_pairs[var.server_pair].primary.resource_group
-  server_name         = data.azurerm_mssql_server.primary_sql_db_server.name
-  databases           = [azurerm_mssql_database.primary_db[count.index].id]
-  partner_servers {
+resource "azurerm_mssql_failover_group" "failover_group" {
+  # When switching from the "azurerm_sql_failover_group" to the "azurerm_mssql_failover_group"
+  # resource type, it's necessary to use a different name to prevent name clashes, so we add
+  # the suffix "-g" just to get a different name.
+  name = format("%s-g", var.instance_name)
+
+  server_id = data.azurerm_mssql_server.primary_sql_db_server.id
+  databases = [azurerm_mssql_database.primary_db[count.index].id]
+  partner_server {
     id = data.azurerm_mssql_server.secondary_sql_db_server.id
   }
 

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
@@ -3,8 +3,8 @@
 locals {
   primary_db_name = (length(azurerm_mssql_database.primary_db) > 0 ? azurerm_mssql_database.primary_db[0].name : "")
   primary_db_id   = (length(azurerm_mssql_database.primary_db) > 0 ? azurerm_mssql_database.primary_db[0].id : "")
-  fog_name        = (length(azurerm_sql_failover_group.failover_group) > 0 ? azurerm_sql_failover_group.failover_group[0].name : "")
-  fog_id          = (length(azurerm_sql_failover_group.failover_group) > 0 ? azurerm_sql_failover_group.failover_group[0].id : "")
+  fog_name        = (length(azurerm_mssql_failover_group.failover_group) > 0 ? azurerm_mssql_failover_group.failover_group[0].name : "")
+  fog_id          = (length(azurerm_mssql_failover_group.failover_group) > 0 ? azurerm_mssql_failover_group.failover_group[0].id : "")
 }
 
 output "sqldbName" { value = var.existing ? var.db_name : local.primary_db_name }


### PR DESCRIPTION
…er_group"

The resource "azurerm_sql_failover_group" has been deprecated and is removed in the next version of the AzureRM provider. In order to prepare for this, we are replacing it with the new alternative "azurerm_mssql_failover_group". Because OpenTofu will run the delete of "azurerm_sql_failover_group" in parallel with the creation of "azurerm_mssql_failover_group", we need to create a resource with a different name so that Azure does not fail with a name conflict error.

- Whether or not `instance_name` is set, a `-g` will be appended to the name of the failover group in Azure
- Because the name of the failover group has changed, existing bindings will cease to work, and apps must be rebound and restaged.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

