### PR TITLE
feat: replace sql_failover_group with mssql_failover_group

### DIFF
--- a/acceptance-tests/helpers/services/upgrade.go
+++ b/acceptance-tests/helpers/services/upgrade.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 
@@ -13,26 +13,15 @@ import (
 
 func (s *ServiceInstance) Upgrade() {
 	if !s.UpgradeAvailable() {
-		fmt.Fprintln(ginkgo.GinkgoWriter, "No Upgrade available for service instance")
+		GinkgoWriter.Println("No Upgrade available for service instance")
 		return
 	}
 
-	var command []string
-	switch cf.Version() {
-	case cf.VersionV8:
-		command = []string{"upgrade-service", s.Name, "--force"}
-	default:
-		command = []string{"update-service", s.Name, "--upgrade", "--force"}
-	}
-
-	session := cf.Start(command...)
+	session := cf.Start("upgrade-service", s.Name, "--force", "--wait")
 	Eventually(session).WithTimeout(asyncCommandTimeout).Should(Exit(0))
 
-	Eventually(func() string {
-		out, _ := cf.Run("service", s.Name)
-		Expect(out).NotTo(MatchRegexp(`status:\s+update failed`))
-		return out
-	}).WithTimeout(operationTimeout).WithPolling(pollingInterval).Should(MatchRegexp(`status:\s+update succeeded`))
+	out, _ := cf.Run("service", s.Name)
+	Expect(out).To(MatchRegexp(`status:\s+update succeeded`))
 
 	Expect(s.UpgradeAvailable()).To(BeFalse(), "service instance has an upgrade available after upgrade")
 }
@@ -50,22 +39,10 @@ func (s *ServiceInstance) UpgradeAvailable() bool {
 func (s *ServiceInstance) UpgradeExpectFailure() {
 	Expect(s.UpgradeAvailable()).To(BeTrue(), "service instance does not have an upgrade available")
 
-	var command []string
-	switch cf.Version() {
-	case cf.VersionV8:
-		command = []string{"upgrade-service", s.Name, "--force"}
-	default:
-		command = []string{"update-service", s.Name, "--upgrade", "--force"}
-	}
+	session := cf.Start("upgrade-service", s.Name, "--force", "--wait")
+	Eventually(session).WithTimeout(asyncCommandTimeout).Should(Exit())
 
-	session := cf.Start(command...)
-	Eventually(session).WithTimeout(asyncCommandTimeout).Should(Exit(0))
-
-	Eventually(func() string {
-		out, _ := cf.Run("service", s.Name)
-		Expect(out).NotTo(MatchRegexp(`status:\s+update succeeded`))
-		return out
-	}).WithTimeout(operationTimeout).WithPolling(pollingInterval).Should(MatchRegexp(`status:\s+update failed`))
-
-	Expect(s.UpgradeAvailable()).To(BeTrue(), "service instance should still have an upgrade available after failure to upgrade")
+	out, _ := cf.Run("service", s.Name)
+	Expect(out).To(MatchRegexp(`status:\s+update failed`))
+	Expect(out).To(MatchRegexp(`message:\s+upgrade failed: Error: A resource with the ID .* already exists`))
 }

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_test.go
@@ -90,15 +90,22 @@ var _ = Describe("UpgradeMssqlDBFailoverGroupTest", Label("mssql-db-failover-gro
 			By("validating that the instance plan is still active")
 			Expect(plans.ExistsAndAvailable(servicePlan, serviceOffering, serviceBroker.Name))
 
-			By("upgrading previous services")
+			// Because the "azurerm_sql_database" resource is deleted at the same time as the "azurerm_mssql_database"
+			// is created, the upgrade will fail due to using the same name in Azure
+			By("upgrading previous services and failing")
+			initialFogInstance.UpgradeExpectFailure()
+
+			// The deletion operation of the "azurerm_sql_database" resource should now have completed, so the
+			// "azurerm_mssql_database" can be created without a name conflict in Azure
+			By("upgrading again and succeeding")
 			initialFogInstance.Upgrade()
 
 			By("getting the previously set value using the second app")
 			got = appTwo.GET("%s/%s", schema, keyOne)
 			Expect(got).To(Equal(valueOne))
 
-			By("updating the instance plan")
-			initialFogInstance.Update("-p", "medium")
+			By("updating the instance")
+			initialFogInstance.Update("-c", "{}")
 
 			By("getting the previously set value using the second app")
 			got = appTwo.GET("%s/%s", schema, keyOne)

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
@@ -40,12 +40,11 @@ resource "azurerm_mssql_database" "secondary_db" {
   count                       = var.existing ? 0 : 1
 }
 
-resource "azurerm_sql_failover_group" "failover_group" {
-  name                = var.instance_name
-  resource_group_name = var.server_credential_pairs[var.server_pair].primary.resource_group
-  server_name         = data.azurerm_mssql_server.primary_sql_db_server.name
-  databases           = [azurerm_mssql_database.primary_db[count.index].id]
-  partner_servers {
+resource "azurerm_mssql_failover_group" "failover_group" {
+  name      = var.instance_name
+  server_id = data.azurerm_mssql_server.primary_sql_db_server.id
+  databases = [azurerm_mssql_database.primary_db[count.index].id]
+  partner_server {
     id = data.azurerm_mssql_server.secondary_sql_db_server.id
   }
 

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-outputs.tf
@@ -3,8 +3,8 @@
 locals {
   primary_db_name = (length(azurerm_mssql_database.primary_db) > 0 ? azurerm_mssql_database.primary_db[0].name : "")
   primary_db_id   = (length(azurerm_mssql_database.primary_db) > 0 ? azurerm_mssql_database.primary_db[0].id : "")
-  fog_name        = (length(azurerm_sql_failover_group.failover_group) > 0 ? azurerm_sql_failover_group.failover_group[0].name : "")
-  fog_id          = (length(azurerm_sql_failover_group.failover_group) > 0 ? azurerm_sql_failover_group.failover_group[0].id : "")
+  fog_name        = (length(azurerm_mssql_failover_group.failover_group) > 0 ? azurerm_mssql_failover_group.failover_group[0].name : "")
+  fog_id          = (length(azurerm_mssql_failover_group.failover_group) > 0 ? azurerm_mssql_failover_group.failover_group[0].id : "")
 }
 
 output "sqldbName" { value = var.existing ? var.db_name : local.primary_db_name }


### PR DESCRIPTION
The resource "azurerm_sql_failover_group" has been deprecated and is removed in the next version of the AzureRM provider. In order to prepare for this, we are replacing it with the new alternative "azurerm_mssql_failover_group". Because OpenTofu will run the delete of "azurerm_sql_failover_group" in parallel with the creation of "azurerm_mssql_failover_group", the upgrade of service instances will fail at the first attempt. But it will succeed on a second attempt. This is not an ideal behavior, but as long as it's expected it's easy to deal with, and alternatives come with a different set of tradeoffs (principally needing to re-bind service instances, or re-engineering the core broker).

Requires core broker fix: https://github.com/cloudfoundry/cloud-service-broker/pull/1179