### PR TITLE
test: fix mssql_db_failover_existing test

### DIFF
--- a/acceptance-tests/helpers/brokers/delete.go
+++ b/acceptance-tests/helpers/brokers/delete.go
@@ -1,8 +1,13 @@
 package brokers
 
-import "csbbrokerpakazure/acceptance-tests/helpers/cf"
+import (
+	"csbbrokerpakazure/acceptance-tests/helpers/cf"
+)
 
 func (b *Broker) Delete() {
+	// This is implicit when deleting the app, but sometimes that fails, so this ensures the resource is freed
+	cf.Run("unbind-service", b.Name, "csb-sql")
+
 	cf.Run("delete-service-broker", b.Name, "-f")
 	b.app.Delete()
 }

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 )
 
-func (b Broker) env() []apps.EnvVar {
+func (b *Broker) env() []apps.EnvVar {
 	var result []apps.EnvVar
 
 	for name, required := range map[string]bool{
@@ -51,6 +51,6 @@ func (b Broker) env() []apps.EnvVar {
 	return append(result, b.envExtras...)
 }
 
-func (b Broker) latestEnv() []apps.EnvVar {
+func (b *Broker) latestEnv() []apps.EnvVar {
 	return readEnvrcServices(testpath.BrokerpakFile(".envrc"))
 }

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_existing_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_existing_test.go
@@ -16,7 +16,6 @@ import (
 
 var _ = Describe("Upgrade and Update csb-azure-mssql-db-failover-group 'existing' plan", Label("mssql-db-failover-group-existing"), func() {
 	When("upgrading broker version", func() {
-
 		It("should continue to work", func() {
 			ctx := context.Background()
 
@@ -25,15 +24,11 @@ var _ = Describe("Upgrade and Update csb-azure-mssql-db-failover-group 'existing
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				GinkgoHelper()
-
 				By("deleting the created resource group and DB servers")
-				err := mssqlserver.Cleanup(ctx, serversConfig, subscriptionID)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(mssqlserver.Cleanup(ctx, serversConfig, subscriptionID)).To(Succeed())
 			})
 
 			By("pushing latest released broker version")
-
 			serviceBroker := brokers.Create(
 				brokers.WithPrefix("csb-db-fo"),
 				brokers.WithSourceDir(releasedBuildDir),
@@ -109,8 +104,16 @@ var _ = Describe("Upgrade and Update csb-azure-mssql-db-failover-group 'existing
 			Expect(plans.ExistsAndAvailable(servicePlan, serviceOffering, serviceBroker.Name))
 			Expect(plans.ExistsAndAvailable(servicePlanExisting, serviceOffering, serviceBroker.Name))
 
-			By("upgrading previous services")
+			By("upgrading previous service, failing first time and then repeating")
+			// Because the "azurerm_sql_database" resource is deleted at the same time as the "azurerm_mssql_database"
+			// is created, the upgrade will fail due to using the same name in Azure
+			initialFogInstance.UpgradeExpectFailure()
+			// The deletion operation of the "azurerm_sql_database" resource should now have completed, so the
+			// "azurerm_mssql_database" can be created without a name conflict in Azure
 			initialFogInstance.Upgrade()
+
+			By("upgrading previous 'existing' service")
+			// Because the "existing" plan does not actually create a failover group, it should not fail to upgrade
 			existingFogInstance.Upgrade()
 
 			By("getting the previously set value using the second app")


### PR DESCRIPTION
- As well as testing the "existing" plan, it used another plan too, and therefore needed changes because of #922
- Also explicitly frees backing database on broker delete, which will hopefully reduce leaking of resources