### PR TITLE
test: simplify MS-SQL tests

### DIFF
--- a/acceptance-tests/mssql_fog_existing_test.go
+++ b/acceptance-tests/mssql_fog_existing_test.go
@@ -1,8 +1,6 @@
 package acceptance_test
 
 import (
-	"context"
-
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/matchers"
@@ -19,15 +17,12 @@ import (
 // Does NOT use the default broker: deploys a custom-configured broker
 var _ = Describe("MSSQL Failover Group Existing", Label("mssql-db-failover-group-existing"), func() {
 	It("can be accessed by an app", func() {
-		ctx := context.Background()
-
 		By("creating primary and secondary DB servers in their resource group")
-		serversConfig, err := mssqlserver.CreateServerPair(ctx, metadata, subscriptionID)
-		Expect(err).NotTo(HaveOccurred())
+		serversConfig := mssqlserver.CreateServerPair(metadata, subscriptionID)
 
 		DeferCleanup(func() {
 			By("deleting the created resource group and DB servers")
-			_ = mssqlserver.Cleanup(ctx, serversConfig, subscriptionID)
+			mssqlserver.Cleanup(serversConfig, subscriptionID)
 		})
 
 		By("deploying the CSB")

--- a/acceptance-tests/mssql_server_and_db_test.go
+++ b/acceptance-tests/mssql_server_and_db_test.go
@@ -1,8 +1,6 @@
 package acceptance_test
 
 import (
-	"context"
-
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/matchers"
@@ -33,19 +31,18 @@ var _ = Describe("MSSQL Server and DB", Label("mssql-db"), func() {
 
 		By("creating a server")
 		dbs := mssqlserver.DatabaseServer{Name: serverConfig.Name, ResourceGroup: metadata.ResourceGroup}
-		ctx := context.Background()
-		Expect(mssqlserver.CreateResourceGroup(ctx, metadata.ResourceGroup, subscriptionID))
-		Expect(mssqlserver.CreateServer(ctx, dbs, serverConfig.Username, serverConfig.Password, subscriptionID)).NotTo(HaveOccurred())
-		defer func() {
+		mssqlserver.CreateResourceGroup(metadata.ResourceGroup, subscriptionID)
+		mssqlserver.CreateServer(dbs, serverConfig.Username, serverConfig.Password, subscriptionID)
+		DeferCleanup(func() {
 			By("deleting the server")
-			_ = mssqlserver.CleanupServer(ctx, dbs, subscriptionID)
-		}()
+			mssqlserver.CleanupServer(dbs, subscriptionID)
+		})
 
-		Expect(mssqlserver.CreateFirewallRule(ctx, metadata, dbs, subscriptionID)).NotTo(HaveOccurred())
-		defer func() {
+		mssqlserver.CreateFirewallRule(metadata, dbs, subscriptionID)
+		DeferCleanup(func() {
 			By("deleting the firewall rule")
-			_ = mssqlserver.CleanFirewallRule(ctx, dbs, subscriptionID)
-		}()
+			mssqlserver.CleanupFirewallRule(dbs, subscriptionID)
+		})
 
 		By("creating a database in the server")
 		const serviceOffering = "csb-azure-mssql-db"

--- a/acceptance-tests/mssql_server_pair_and_fog_db_test.go
+++ b/acceptance-tests/mssql_server_pair_and_fog_db_test.go
@@ -1,8 +1,6 @@
 package acceptance_test
 
 import (
-	"context"
-
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/matchers"
@@ -18,15 +16,12 @@ import (
 // Does NOT use the default broker: deploys a custom-configured broker
 var _ = Describe("MSSQL Server Pair and Failover Group DB", Label("mssql-db-failover-group"), func() {
 	It("can be accessed by an app", func() {
-		ctx := context.Background()
-
 		By("creating primary and secondary DB servers in their resource group")
-		serversConfig, err := mssqlserver.CreateServerPair(ctx, metadata, subscriptionID)
-		Expect(err).NotTo(HaveOccurred())
+		serversConfig := mssqlserver.CreateServerPair(metadata, subscriptionID)
 
 		DeferCleanup(func() {
 			By("deleting the created resource group and DB servers")
-			_ = mssqlserver.Cleanup(ctx, serversConfig, subscriptionID)
+			mssqlserver.Cleanup(serversConfig, subscriptionID)
 		})
 
 		By("Create CSB with server details")

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_existing_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_existing_test.go
@@ -1,8 +1,6 @@
 package upgrade_test
 
 import (
-	"context"
-
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/mssqlserver"
@@ -17,15 +15,12 @@ import (
 var _ = Describe("Upgrade and Update csb-azure-mssql-db-failover-group 'existing' plan", Label("mssql-db-failover-group-existing"), func() {
 	When("upgrading broker version", func() {
 		It("should continue to work", func() {
-			ctx := context.Background()
-
 			By("creating primary and secondary DB servers in their resource group")
-			serversConfig, err := mssqlserver.CreateServerPair(ctx, metadata, subscriptionID)
-			Expect(err).NotTo(HaveOccurred())
+			serversConfig := mssqlserver.CreateServerPair(metadata, subscriptionID)
 
 			DeferCleanup(func() {
 				By("deleting the created resource group and DB servers")
-				Expect(mssqlserver.Cleanup(ctx, serversConfig, subscriptionID)).To(Succeed())
+				mssqlserver.Cleanup(serversConfig, subscriptionID)
 			})
 
 			By("pushing latest released broker version")

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_group_test.go
@@ -1,8 +1,6 @@
 package upgrade_test
 
 import (
-	"context"
-
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/mssqlserver"
@@ -17,19 +15,12 @@ import (
 var _ = Describe("UpgradeMssqlDBFailoverGroupTest", Label("mssql-db-failover-group"), func() {
 	When("upgrading broker version", func() {
 		It("should continue to work", func() {
-
-			ctx := context.Background()
-
 			By("creating primary and secondary DB servers in their resource group")
-			serversConfig, err := mssqlserver.CreateServerPair(ctx, metadata, subscriptionID)
-			Expect(err).NotTo(HaveOccurred())
+			serversConfig := mssqlserver.CreateServerPair(metadata, subscriptionID)
 
 			DeferCleanup(func() {
-				GinkgoHelper()
-
 				By("deleting the created resource group and DB servers")
-				err := mssqlserver.Cleanup(ctx, serversConfig, subscriptionID)
-				Expect(err).NotTo(HaveOccurred())
+				mssqlserver.Cleanup(serversConfig, subscriptionID)
 			})
 
 			By("pushing latest released broker version")

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_test.go
@@ -1,8 +1,6 @@
 package upgrade_test
 
 import (
-	"context"
-
 	"csbbrokerpakazure/acceptance-tests/helpers/apps"
 	"csbbrokerpakazure/acceptance-tests/helpers/brokers"
 	"csbbrokerpakazure/acceptance-tests/helpers/mssqlserver"
@@ -28,19 +26,18 @@ var _ = Describe("UpgradeMssqlDBTest", Label("mssql-db"), func() {
 			By("creating a service")
 			serverConfig := newDatabaseServer()
 			dbs := mssqlserver.DatabaseServer{Name: serverConfig.Name, ResourceGroup: metadata.ResourceGroup}
-			ctx := context.Background()
-			Expect(mssqlserver.CreateResourceGroup(ctx, metadata.ResourceGroup, subscriptionID))
-			Expect(mssqlserver.CreateServer(ctx, dbs, serverConfig.Username, serverConfig.Password, subscriptionID)).NotTo(HaveOccurred())
+			mssqlserver.CreateResourceGroup(metadata.ResourceGroup, subscriptionID)
+			mssqlserver.CreateServer(dbs, serverConfig.Username, serverConfig.Password, subscriptionID)
 			defer func() {
 				By("deleting the server")
-				_ = mssqlserver.CleanupServer(ctx, dbs, subscriptionID)
+				mssqlserver.CleanupServer(dbs, subscriptionID)
 			}()
 
-			Expect(mssqlserver.CreateFirewallRule(ctx, metadata, dbs, subscriptionID)).NotTo(HaveOccurred())
-			defer func() {
+			mssqlserver.CreateFirewallRule(metadata, dbs, subscriptionID)
+			DeferCleanup(func() {
 				By("deleting the firewall rule")
-				_ = mssqlserver.CleanFirewallRule(ctx, dbs, subscriptionID)
-			}()
+				mssqlserver.CleanupFirewallRule(dbs, subscriptionID)
+			})
 
 			By("reconfiguring the CSB with DB server details")
 			serverTag := random.Name(random.WithMaxLength(10))

--- a/terraform/azure-mongodb/provision/main.tf
+++ b/terraform/azure-mongodb/provision/main.tf
@@ -30,12 +30,12 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_cosmosdb_account" "mongo-account" {
-  depends_on          = [azurerm_resource_group.rg]
-  name                = var.account_name
-  location            = var.location
-  resource_group_name = local.resource_group
-  offer_type          = "Standard"
-  kind                = "MongoDB"
+  depends_on           = [azurerm_resource_group.rg]
+  name                 = var.account_name
+  location             = var.location
+  resource_group_name  = local.resource_group
+  offer_type           = "Standard"
+  kind                 = "MongoDB"
   mongo_server_version = var.server_version
 
   consistency_policy {


### PR DESCRIPTION
- In a test, there's no value in passing around context.Context if you don't do anything with it
- In a test, there's no value in returning an error if all callers will fail on the error
- It's better to use Ginkgo's DeferCleanup() than a Go defer() as it has better logging