### PR TITLE
chore: revert to OpenTofu v1.9

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,11 +26,11 @@ terraform_state_provider_replacements:
   registry.terraform.io/cloud-service-broker/csbsqlserver: "cloudfoundry.org/cloud-service-broker/csbsqlserver"
   registry.terraform.io/cloud-service-broker/csbmssqldbrunfailover: "cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover"
 terraform_upgrade_path:
-- version: 1.10.1
+- version: 1.9.1
 terraform_binaries:
 - name: tofu
-  version: 1.10.1
-  source: https://github.com/opentofu/opentofu/archive/v1.10.1.zip
+  version: 1.9.1
+  source: https://github.com/opentofu/opentofu/archive/v1.9.1.zip
   default: true
 - name: terraform-provider-azurerm
   version: 4.34.0


### PR DESCRIPTION
There is a behaviour change in OpenTofu v1.10, and while we work out how to deal with it, we will switch back to v1.9.1

https://github.com/opentofu/opentofu/issues/2977