### PR TITLE
TNZ-101746: chore: Update OpenTofu to 1.11.5

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,11 +26,11 @@ terraform_state_provider_replacements:
   registry.terraform.io/cloud-service-broker/csbsqlserver: "cloudfoundry.org/cloud-service-broker/csbsqlserver"
   registry.terraform.io/cloud-service-broker/csbmssqldbrunfailover: "cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover"
 terraform_upgrade_path:
-- version: 1.10.9
+- version: 1.11.5
 terraform_binaries:
 - name: tofu
-  version: 1.10.9
-  source: https://github.com/opentofu/opentofu/archive/v1.10.9.zip
+  version: 1.11.5
+  source: https://github.com/opentofu/opentofu/archive/v1.11.5.zip
   default: true
 - name: terraform-provider-azurerm
   version: 4.66.0


### PR DESCRIPTION
## Summary
* Updates OpenTofu minor version from 1.10.9 to 1.11.5.
* The CI will continue to automatically bump patch versions for the 1.11.x line.

Made with [Cursor](https://cursor.com)