### PR TITLE
fix: dependabot PR merge

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,8 +22,35 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: make test
-  call-dependabot-pr-workflow:
+
+  wait-for-checks:
     needs: test
+    runs-on: ubuntu-latest
+    if: ${{ success() && github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Wait for other checks to finish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for i in {1..60}; do
+            pending=$(gh pr checks ${{ github.event.number }} --repo ${{ github.repository }} --json name,state -q '[.[] | select(.name != "call-dependabot-pr-workflow / Merge Dependabot Pull Pequest" and .name != "wait-for-checks" and (.state == "PENDING" or .state == "IN_PROGRESS"))] | length' || echo "error")
+            if [ "$pending" = "error" ]; then
+              echo "Error checking PR status, retrying ($i/60)..."
+              sleep 10
+              continue
+            fi
+            if [ "$pending" -eq 0 ]; then
+              echo "All checks finished!"
+              exit 0
+            fi
+            echo "Waiting for $pending checks to finish ($i/60)..."
+            sleep 10
+          done
+          echo "Timeout waiting for checks to finish after 10 minutes."
+          exit 1
+
+  call-dependabot-pr-workflow:
+    needs: wait-for-checks
     if: ${{ success() && github.actor == 'dependabot[bot]' }}
     uses: cloudfoundry/cloud-service-broker/.github/workflows/dependabot-test.yml@main
     with:


### PR DESCRIPTION
## Summary
- Adds a `wait-for-checks` job to ensure all required checks finish before calling the dependabot merge workflow, preventing 405 errors.
- The job polls every 10 seconds for up to 10 minutes (60 attempts) before timing out, to prevent it from running indefinitely if something goes wrong.

Note: The `setup-terraform` workaround was removed from this PR since `hc-install` was updated to `v0.9.4` in PR #1124, which natively fixes the GPG key expiration issue.

## Test plan
- Wait for tests to pass on this PR.
- Check if dependabot PRs merge successfully.
